### PR TITLE
Boilerplate for setting up remote debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,55 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+//     "version": "0.2.0",
+//     "configurations": [
+//         {
+//             "name": "Launch test function",
+//             "type": "go",
+//             "request": "launch",
+//             "mode": "test",
+//             "program": "${workspaceFolder}",
+//             "args": [
+//                 "-test.run",
+//                 "MyTestFunction"
+//             ]
+//         },
+// {
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "remotePath": "",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "program": "${workspaceRoot}",
+            "env": {},
+            "args": [],
+            "showLog": true
+        },
+        {
+            "name": "Test Current File",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "remotePath": "",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "program": "${file}",
+            "env": {},
+            "args": [],
+            "showLog": true
+        },
+        {
+            "name": "Launch test package",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${file}"
+        }       
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
+RUN go get -u github.com/go-delve/delve/cmd/dlv
 
 # Copy the go source
 COPY main.go main.go
@@ -17,15 +18,14 @@ COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+# Rebuild with debug symbols
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -gcflags="all=-N -l" -o manager-debug main.go
 
 FROM golang:1.15 as debug
 COPY --from=builder /workspace/ .
 COPY --from=builder /go/bin/dlv /usr/local/bin/
 COPY start.sh .
 ENV DEBUG "TRUE"
-# Rebuild with debug symbols
-RUN go get -u github.com/go-delve/delve/cmd/dlv
-RUN  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -gcflags="all=-N -l" -o manager main.go
 ENTRYPOINT ["./start.sh"]
 
 # Use distroless as minimal base image to package the manager binary

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ all: manager
 
 # Run tests
 test: generate fmt vet manifests
-	([[ "$(SKIP_TESTS)" != "TRUE" ]] && ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress) || echo "Some tests failed or where skipped.."
+	@if [ "$(SKIP_TESTS)" != "TRUE" ]; then \
+		ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress ; \
+	fi
 
 install-ci:
 	go get -v github.com/onsi/ginkgo/ginkgo

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ To facilitate local debugging and testing against real clusters, you may run:
 bash hack/install-dev-deps.sh
 bash hack/setup-dev.sh [argocd-version] [appset-version]
 make install
+make docker-build
 make deploy
 ```
 

--- a/charts/argocd-progressive-rollout/templates/deployment.yaml
+++ b/charts/argocd-progressive-rollout/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           command:
-            - /manager
+            - /start.sh
             - --metrics-addr={{ .Values.args.metricsAddr }}
             {{- if or (gt ( .Values.replicaCount | int64) 1) .Values.args.enableLeaderElection }}
             - --enable-leader-election=true

--- a/config/crd/bases/deployment.skyscanner.net_progressiverollouts.yaml
+++ b/config/crd/bases/deployment.skyscanner.net_progressiverollouts.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: progressiverollouts.deployment.skyscanner.net
 spec:
@@ -15,215 +15,161 @@ spec:
     plural: progressiverollouts
     singular: progressiverollout
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ProgressiveRollout is the Schema for the progressiverollouts API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ProgressiveRolloutSpec defines the desired state of ProgressiveRollout
-          properties:
-            sourceRef:
-              description: SourceRef defines the resource, example an ApplicationSet,
-                which owns ArgoCD Applications
-              properties:
-                apiGroup:
-                  description: APIGroup is the group for the resource being referenced.
-                    If APIGroup is not specified, the specified Kind must be in the
-                    core API group. For any other third-party types, APIGroup is required.
-                  type: string
-                kind:
-                  description: Kind is the type of resource being referenced
-                  type: string
-                name:
-                  description: Name is the name of resource being referenced
-                  type: string
-              required:
-              - kind
-              - name
-              type: object
-            stages:
-              description: Stages defines a list of Progressive Rollout stages
-              items:
-                description: ProgressiveRolloutStage defines a rollout stage
-                properties:
-                  maxParallel:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: MaxParallel is how many selected targets to update
-                      in parallel
-                    x-kubernetes-int-or-string: true
-                  maxTargets:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: MaxTargets is the maximum number of selected targets
-                      to update
-                    x-kubernetes-int-or-string: true
-                  name:
-                    description: Name is a human friendly name for the stage
-                    type: string
-                  targets:
-                    description: Targets is the targets to update in the stage
-                    properties:
-                      clusters:
-                        description: Clusters is the a cluster type of targets
-                        properties:
-                          selector:
-                            description: Selector is a label selector to get the clusters
-                              for the update
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                        required:
-                        - selector
-                        type: object
-                    type: object
-                required:
-                - maxParallel
-                - maxTargets
-                - name
-                type: object
-              type: array
-          required:
-          - sourceRef
-          type: object
-        status:
-          description: ProgressiveRolloutStatus defines the observed state of ProgressiveRollout
-          properties:
-            conditions:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
-                this file'
-              items:
-                description: "Condition contains details for one aspect of the current
-                  state of this API Resource. --- This struct is intended for direct
-                  use as an array at the field path .status.conditions.  For example,
-                  type FooStatus struct{     // Represents the observations of a foo's
-                  current state.     // Known .status.conditions.type are: \"Available\",
-                  \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     //
-                  +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                  \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                  \n     // other fields }"
-                properties:
-                  lastTransitionTime:
-                    description: lastTransitionTime is the last time the condition
-                      transitioned from one status to another. This should be when
-                      the underlying condition changed.  If that is not known, then
-                      using the time when the API field changed is acceptable.
-                    format: date-time
-                    type: string
-                  message:
-                    description: message is a human readable message indicating details
-                      about the transition. This may be an empty string.
-                    maxLength: 32768
-                    type: string
-                  observedGeneration:
-                    description: observedGeneration represents the .metadata.generation
-                      that the condition was set based upon. For instance, if .metadata.generation
-                      is currently 12, but the .status.conditions[x].observedGeneration
-                      is 9, the condition is out of date with respect to the current
-                      state of the instance.
-                    format: int64
-                    minimum: 0
-                    type: integer
-                  reason:
-                    description: reason contains a programmatic identifier indicating
-                      the reason for the condition's last transition. Producers of
-                      specific condition types may define expected values and meanings
-                      for this field, and whether the values are considered a guaranteed
-                      API. The value should be a CamelCase string. This field may
-                      not be empty.
-                    maxLength: 1024
-                    minLength: 1
-                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    type: string
-                  status:
-                    description: status of the condition, one of True, False, Unknown.
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      --- Many .condition.type values are consistent across resources
-                      like Available, but because arbitrary conditions can be useful
-                      (see .node.status.conditions), the ability to deconflict is
-                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                    maxLength: 316
-                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                    type: string
-                required:
-                - lastTransitionTime
-                - message
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ProgressiveRollout is the Schema for the progressiverollouts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProgressiveRolloutSpec defines the desired state of ProgressiveRollout
+            properties:
+              sourceRef:
+                description: SourceRef defines the resource, example an ApplicationSet, which owns ArgoCD Applications
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              stages:
+                description: Stages defines a list of Progressive Rollout stages
+                items:
+                  description: ProgressiveRolloutStage defines a rollout stage
+                  properties:
+                    maxParallel:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: MaxParallel is how many selected targets to update in parallel
+                      x-kubernetes-int-or-string: true
+                    maxTargets:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: MaxTargets is the maximum number of selected targets to update
+                      x-kubernetes-int-or-string: true
+                    name:
+                      description: Name is a human friendly name for the stage
+                      type: string
+                    targets:
+                      description: Targets is the targets to update in the stage
+                      properties:
+                        clusters:
+                          description: Clusters is the a cluster type of targets
+                          properties:
+                            selector:
+                              description: Selector is a label selector to get the clusters for the update
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                          required:
+                          - selector
+                          type: object
+                      type: object
+                  required:
+                  - maxParallel
+                  - maxTargets
+                  - name
+                  type: object
+                type: array
+            required:
+            - sourceRef
+            type: object
+          status:
+            description: ProgressiveRolloutStatus defines the observed state of ProgressiveRollout
+            properties:
+              conditions:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: controller
-  newTag: latest
+  newTag: 0.0.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: controller
-  newTag: 0.0.1
+  newTag: 0.0.1-debug

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,10 +28,11 @@ spec:
             secretName: prc-config
       containers:
       - command:
-        - /manager
+        - /start
         args:
         - --enable-leader-election
         image: controller:latest
+        # imagePullPolicy: Never
         name: manager
         resources:
           limits:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,10 +28,14 @@ spec:
             secretName: prc-config
       containers:
       - command:
-        - /start
+        - ./start.sh
         args:
         - --enable-leader-election
         image: controller:latest
+        # TODO: Kustomize this based on env
+        ports:
+        - containerPort: 2345
+          name: delve-dbg-port
         # imagePullPolicy: Never
         name: manager
         resources:

--- a/config/samples/testprog.yml
+++ b/config/samples/testprog.yml
@@ -1,0 +1,20 @@
+apiVersion: deployment.skyscanner.net/v1alpha1
+kind: ProgressiveRollout
+metadata:
+  name: go-infrabin
+  namespace: argocd
+spec:
+  sourceRef:
+    apiGroup: argoproj.io/v1alpha1
+    kind: ApplicationSet
+    name: go-infrabin
+  stages:
+    - name: deploy to in-cluster
+      maxParallel: 1
+      maxTargets: 1
+      targets:
+        clusters:
+          selector:
+            matchLabels:
+              name: in-cluster
+

--- a/delve-debugger-service.yml
+++ b/delve-debugger-service.yml
@@ -1,0 +1,29 @@
+
+# TODO: Create this service when make deploying a debug version to local kind cluster
+# This will also require the creation of the following:
+# docker run \                                                                                                                                                                      (base) 
+#     --name apr-delve-socat-proxy \
+#     --detach \
+#     --restart always \
+#     --publish 2345:2345 \
+#     --link argocd-control-plane-control-plane:target \
+#     --network kind \
+#     alpine/socat \
+#     tcp-listen:2345,fork,reuseaddr tcp-connect:target:2345
+# to create a port forward to the docker container that is hosting the controlplane.
+# We could add this either to `make deploy` command, or to the control cluster creation script
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: apr-delve-service
+  namespace: argocd
+spec:
+  ports:
+  - name: delve-dbg-port
+    port: 2345
+    targetPort: delve-dbg-port
+  selector:
+    control-plane: controller-manager

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ if [[ "${DEBUG}" == "TRUE" ]]; then
     # or your debugger loses connection, delve process wil be left hanging without being able to reconnect
     # You will have to manually kill it or recycle the pod if this is deployed to k8s..
     echo "Starting manager in debug mode"
-    dlv --listen=:2345 --headless=true --api-version=2 exec ./manager -- "$@"
+    dlv --listen=:2345 --headless=true --api-version=2 exec ./manager-debug -- "$@"
 else
     echo "Starting manager in release mode"
     ./manager "$@"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash 
+printenv
+
+if [[ "${DEBUG}" == "TRUE" ]]; then
+    # Delve in headless mode ignores SIGINT (ctrl+c), so the only way to kill it is
+    # to invoke kill DELVE_PID from another process. This has an interesting side-effect, if the applicatio being debugged dies
+    # or your debugger loses connection, delve process wil be left hanging without being able to reconnect
+    # You will have to manually kill it or recycle the pod if this is deployed to k8s..
+    echo "Starting manager in debug mode"
+    dlv --listen=:2345 --headless=true --api-version=2 exec ./manager -- "$@"
+else
+    echo "Starting manager in release mode"
+    ./manager "$@"
+fi


### PR DESCRIPTION
Allows us to create a debug version of the image that runs delve debugging server that we could attach to. Useful for debugging both within the local kind cluster and potentially we could consider deploying a debug image as well when we need to debug something in production.

Currently missing:
* A way to kustomize adding ports to the manager container to allow connecting to delve
* Creation of socat proxy for exposing port 2345 on the local network
* Readme instructions
* A make target/script to setup the boilerplating for debugging
* Configuration for IDE's other than vscode for attaching to the remote debugger.