### PR TITLE
Ensure objects are created in a consistent way without pointers

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -87,11 +87,11 @@ var _ = BeforeSuite(func(done Done) {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	mockAcdClient := &mocks.ArgoCDAppClientStub{}
+	mockAcdClient := mocks.ArgoCDAppClientStub{}
 	reconciler = &ProgressiveSyncReconciler{
 		Client:          k8sManager.GetClient(),
 		Log:             ctrl.Log.WithName("controllers").WithName("progressiverollout"),
-		ArgoCDAppClient: mockAcdClient,
+		ArgoCDAppClient: &mockAcdClient,
 	}
 	err = reconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
# Summary

- fixes #71 
- ensure that all objects/structs are created as their type, then referenced when used as per issue
 