### PR TITLE
Fix potential race condition and remove ambiguity with BeforeEach

### DIFF
--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -516,8 +516,8 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 	Describe("sync application", func() {
 		It("should send a request to sync an application", func() {
-			mockedArgoCDAppClient := &mocks.MockArgoCDAppClientCalledWith{}
-			reconciler.ArgoCDAppClient = mockedArgoCDAppClient
+			mockedArgoCDAppClient := mocks.MockArgoCDAppClientCalledWith{}
+			reconciler.ArgoCDAppClient = &mockedArgoCDAppClient
 			testAppName := "single-stage-app"
 
 			By("creating an ArgoCD cluster")

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -37,12 +37,11 @@ var (
 func createRandomNamespace() (string, *corev1.Namespace) {
 	namespace := "progressiverollout-test-" + randStringNumber(5)
 
-	ns := &corev1.Namespace{
+	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: namespace},
 	}
-	err := k8sClient.Create(ctx, ns)
-	Expect(err).To(BeNil(), "failed to create test namespace")
-	return namespace, ns
+	Expect(k8sClient.Create(ctx, &ns)).To(Succeed())
+	return namespace, &ns
 }
 
 func createOwnerPR(ns string, owner string) *syncv1alpha1.ProgressiveSync {
@@ -97,8 +96,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				Name:      "owner-pr",
 			}))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 
 		It("should filter out events for non-owned applications", func() {
@@ -125,8 +123,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return len(requests)
 			}).Should(Equal(0))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 	})
 
@@ -168,8 +165,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return len(requests)
 			}).Should(Equal(1))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 
 		It("should not forward an event for a generic secret", func() {
@@ -186,8 +182,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return len(requests)
 			}).Should(Equal(0))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 
 		It("should not forward an event for an argocd secret not matching any application", func() {
@@ -225,8 +220,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return len(requests)
 			}).Should(Equal(0))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 	})
 
@@ -265,8 +259,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Expect(err).To(BeNil())
 			Eventually(func() int { return len(appOne.Annotations) }).Should(Equal(1))
 			Eventually(func() int { return len(appTwo.Annotations) }).Should(Equal(1))
-			err = k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 	})
 
@@ -412,8 +405,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&twoStagesPR), &deletedPR)
 				return err
 			}).Should(HaveOccurred())
-			err := k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 
 		It("should fail if unable to sync application", func() {
@@ -521,8 +513,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &deletedPR)
 				return err
 			}).Should(HaveOccurred())
-			err := k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 	})
 
@@ -587,8 +578,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Eventually(func() []string {
 				return mockedArgoCDAppClient.GetSyncedApps()
 			}).Should(ContainElement(testAppName))
-			err := k8sClient.Delete(ctx, ns)
-			Expect(err).To(BeNil(), "failed to delete test namespace")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 		})
 	})
 })

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -29,60 +29,50 @@ const (
 	interval = time.Millisecond * 10
 )
 
-var _ = Describe("ProgressiveSync Controller", func() {
+var (
+	appSetAPIRef = utils.AppSetAPIGroup
+)
 
-	var (
-		ctx                     context.Context
-		namespace, appSetAPIRef string
-		ns                      *corev1.Namespace
-		ownerPR, singleStagePR  *syncv1alpha1.ProgressiveSync
-	)
+func createRandomNamespace() (string, *corev1.Namespace) {
+	namespace := "progressiverollout-test-" + randStringNumber(5)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}
+	err := k8sClient.Create(context.Background(), ns)
+	Expect(err).To(BeNil(), "failed to create test namespace")
+	return namespace, ns
+}
+
+func createOwnerPR(ns string, owner string) *syncv1alpha1.ProgressiveSync {
+	return &syncv1alpha1.ProgressiveSync{
+		ObjectMeta: metav1.ObjectMeta{Name: owner, Namespace: ns},
+		Spec: syncv1alpha1.ProgressiveSyncSpec{
+			SourceRef: corev1.TypedLocalObjectReference{
+				APIGroup: &appSetAPIRef,
+				Kind:     utils.AppSetKind,
+				Name:     "owner-app-set",
+			},
+			Stages: nil,
+		}}
+}
+
+var _ = Describe("ProgressiveRollout Controller", func() {
 
 	appSetAPIRef = utils.AppSetAPIGroup
 	// See https://onsi.github.io/gomega#modifying-default-intervals
 	SetDefaultEventuallyTimeout(timeout)
 	SetDefaultEventuallyPollingInterval(interval)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		namespace = "progressivesync-test-" + randStringNumber(5)
-
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: namespace},
-		}
-		err := k8sClient.Create(context.Background(), ns)
-		Expect(err).To(BeNil(), "failed to create test namespace")
-
-		reconciler.ArgoCDAppClient = &mocks.ArgoCDAppClientStub{}
-	})
-
-	AfterEach(func() {
-		err := k8sClient.Delete(context.Background(), ns)
-		Expect(err).To(BeNil(), "failed to delete test namespace")
-	})
+	ctx := context.Background()
 
 	Describe("requestsForApplicationChange function", func() {
 
-		JustBeforeEach(func() {
-			ownerPR = &syncv1alpha1.ProgressiveSync{
-				ObjectMeta: metav1.ObjectMeta{Name: "owner-pr", Namespace: namespace},
-				Spec: syncv1alpha1.ProgressiveSyncSpec{
-					SourceRef: corev1.TypedLocalObjectReference{
-						APIGroup: &appSetAPIRef,
-						Kind:     utils.AppSetKind,
-						Name:     "owner-app-set",
-					},
-					Stages: nil,
-				}}
-			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-		})
-
 		It("should forward events for owned applications", func() {
 			By("creating an owned application")
+
+			namespace, ns := createRandomNamespace()
+			ownerPR := createOwnerPR(namespace, "owner-pr")
+			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
 			ownedApp := argov1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "app",
@@ -106,10 +96,16 @@ var _ = Describe("ProgressiveSync Controller", func() {
 				Namespace: namespace,
 				Name:      "owner-pr",
 			}))
+			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 
 		It("should filter out events for non-owned applications", func() {
 			By("creating a non-owned application")
+			namespace, ns := createRandomNamespace()
+			ownerPR := createOwnerPR(namespace, "owner-pr")
+			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
 			nonOwnedApp := argov1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "non-owned-app",
@@ -128,31 +124,20 @@ var _ = Describe("ProgressiveSync Controller", func() {
 				requests := reconciler.requestsForApplicationChange(&nonOwnedApp)
 				return len(requests)
 			}).Should(Equal(0))
+			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
 
 	Describe("requestsForSecretChange function", func() {
 
-		JustBeforeEach(func() {
-			ownerPR = &syncv1alpha1.ProgressiveSync{
-				ObjectMeta: metav1.ObjectMeta{Name: "owner-pr", Namespace: namespace},
-				Spec: syncv1alpha1.ProgressiveSyncSpec{
-					SourceRef: corev1.TypedLocalObjectReference{
-						APIGroup: &appSetAPIRef,
-						Kind:     utils.AppSetKind,
-						Name:     "owner-app-set",
-					},
-					Stages: nil,
-				}}
-			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-		})
-
 		It("should forward an event for a matching argocd secret", func() {
+			namespace, ns := createRandomNamespace()
+			ownerPR := createOwnerPR(namespace, "owner-pr")
+			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
 			serverURL := "https://kubernetes.default.svc"
+
 			By("creating an application")
 			app := argov1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
@@ -182,9 +167,15 @@ var _ = Describe("ProgressiveSync Controller", func() {
 				requests := reconciler.requestsForSecretChange(&cluster)
 				return len(requests)
 			}).Should(Equal(1))
+			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 
 		It("should not forward an event for a generic secret", func() {
+			namespace, ns := createRandomNamespace()
+			ownerPR := createOwnerPR(namespace, "owner-pr")
+			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
 			By("creating a generic secret")
 			generic := corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "generic", Namespace: namespace}, Data: map[string][]byte{"secret": []byte("insecure")},
@@ -194,9 +185,16 @@ var _ = Describe("ProgressiveSync Controller", func() {
 				requests := reconciler.requestsForSecretChange(&generic)
 				return len(requests)
 			}).Should(Equal(0))
+			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 
 		It("should not forward an event for an argocd secret not matching any application", func() {
+			namespace, ns := createRandomNamespace()
+			ownerPR := createOwnerPR(namespace, "owner-pr")
+			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
+
 			By("creating an application")
 			externalApp := argov1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
@@ -226,12 +224,16 @@ var _ = Describe("ProgressiveSync Controller", func() {
 				requests := reconciler.requestsForSecretChange(&internalCluster)
 				return len(requests)
 			}).Should(Equal(0))
+			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
 
 	Describe("removeAnnotationFromApps function", func() {
 		It("should remove the target annotation from the given apps", func() {
 			By("creating two applications with two annotations")
+			namespace, ns := createRandomNamespace()
 			appOne := argov1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "app-one",
@@ -263,11 +265,14 @@ var _ = Describe("ProgressiveSync Controller", func() {
 			Expect(err).To(BeNil())
 			Eventually(func() int { return len(appOne.Annotations) }).Should(Equal(1))
 			Eventually(func() int { return len(appTwo.Annotations) }).Should(Equal(1))
+			err = k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
 
 	Describe("reconciliation loop", func() {
 		It("should reconcile two stages", func() {
+			namespace, ns := createRandomNamespace()
 			testPrefix := "two-stages"
 
 			By("creating 2 ArgoCD cluster")
@@ -407,9 +412,12 @@ var _ = Describe("ProgressiveSync Controller", func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&twoStagesPR), &deletedPR)
 				return err
 			}).Should(HaveOccurred())
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 
 		It("should fail if unable to sync application", func() {
+			namespace, ns := createRandomNamespace()
 			testPrefix := "failed-stages"
 
 			By("creating 2 ArgoCD cluster")
@@ -513,13 +521,16 @@ var _ = Describe("ProgressiveSync Controller", func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &deletedPR)
 				return err
 			}).Should(HaveOccurred())
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
 
 	Describe("sync application", func() {
 		It("should send a request to sync an application", func() {
-			mockedArgoCDAppClient := mocks.MockArgoCDAppClientCalledWith{}
-			reconciler.ArgoCDAppClient = &mockedArgoCDAppClient
+			namespace, ns := createRandomNamespace()
+			mockedArgoCDAppClient := &mocks.MockArgoCDAppClientCalledWith{}
+			reconciler.ArgoCDAppClient = mockedArgoCDAppClient
 			testAppName := "single-stage-app"
 
 			By("creating an ArgoCD cluster")
@@ -553,7 +564,7 @@ var _ = Describe("ProgressiveSync Controller", func() {
 			Expect(k8sClient.Create(ctx, &singleStageApp)).To(Succeed())
 
 			By("creating a progressive sync")
-			singleStagePR = &syncv1alpha1.ProgressiveSync{
+			singleStagePR := syncv1alpha1.ProgressiveSync{
 				ObjectMeta: metav1.ObjectMeta{Name: "single-stage-pr", Namespace: namespace},
 				Spec: syncv1alpha1.ProgressiveSyncSpec{
 					SourceRef: corev1.TypedLocalObjectReference{
@@ -571,11 +582,13 @@ var _ = Describe("ProgressiveSync Controller", func() {
 					}},
 				},
 			}
-			Expect(k8sClient.Create(ctx, singleStagePR)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &singleStagePR)).To(Succeed())
 
 			Eventually(func() []string {
 				return mockedArgoCDAppClient.GetSyncedApps()
 			}).Should(ContainElement(testAppName))
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
 })

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -31,6 +31,7 @@ const (
 
 var (
 	appSetAPIRef = utils.AppSetAPIGroup
+	ctx          = context.Background()
 )
 
 func createRandomNamespace() (string, *corev1.Namespace) {
@@ -39,7 +40,7 @@ func createRandomNamespace() (string, *corev1.Namespace) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: namespace},
 	}
-	err := k8sClient.Create(context.Background(), ns)
+	err := k8sClient.Create(ctx, ns)
 	Expect(err).To(BeNil(), "failed to create test namespace")
 	return namespace, ns
 }
@@ -63,7 +64,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 	// See https://onsi.github.io/gomega#modifying-default-intervals
 	SetDefaultEventuallyTimeout(timeout)
 	SetDefaultEventuallyPollingInterval(interval)
-	ctx := context.Background()
 
 	Describe("requestsForApplicationChange function", func() {
 
@@ -97,7 +97,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				Name:      "owner-pr",
 			}))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(context.Background(), ns)
+			err := k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 
@@ -125,7 +125,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return len(requests)
 			}).Should(Equal(0))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(context.Background(), ns)
+			err := k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
@@ -168,7 +168,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return len(requests)
 			}).Should(Equal(1))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(context.Background(), ns)
+			err := k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 
@@ -186,7 +186,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return len(requests)
 			}).Should(Equal(0))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(context.Background(), ns)
+			err := k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 
@@ -225,7 +225,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return len(requests)
 			}).Should(Equal(0))
 			Expect(k8sClient.Delete(ctx, ownerPR)).To(Succeed())
-			err := k8sClient.Delete(context.Background(), ns)
+			err := k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
@@ -265,7 +265,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Expect(err).To(BeNil())
 			Eventually(func() int { return len(appOne.Annotations) }).Should(Equal(1))
 			Eventually(func() int { return len(appTwo.Annotations) }).Should(Equal(1))
-			err = k8sClient.Delete(context.Background(), ns)
+			err = k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
@@ -412,7 +412,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&twoStagesPR), &deletedPR)
 				return err
 			}).Should(HaveOccurred())
-			err := k8sClient.Delete(context.Background(), ns)
+			err := k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 
@@ -521,7 +521,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &deletedPR)
 				return err
 			}).Should(HaveOccurred())
-			err := k8sClient.Delete(context.Background(), ns)
+			err := k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})
@@ -587,7 +587,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Eventually(func() []string {
 				return mockedArgoCDAppClient.GetSyncedApps()
 			}).Should(ContainElement(testAppName))
-			err := k8sClient.Delete(context.Background(), ns)
+			err := k8sClient.Delete(ctx, ns)
 			Expect(err).To(BeNil(), "failed to delete test namespace")
 		})
 	})


### PR DESCRIPTION
This PR attempts to fix several race conditions that manifest in different ways:
#83, #81

I suspect this is coming from the use of `BeforeEach`, resetting the `namespace` name but being used later in the test.
It is a global scope, so by making it local I think we'll remove the issue.