### PR TITLE
Reuse context in reconciler

### DIFF
--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -257,7 +257,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Expect(k8sClient.Create(ctx, &appTwo)).To(Succeed())
 
 			apps := []argov1alpha1.Application{appOne, appTwo}
-			err := reconciler.removeAnnotationFromApps(apps, "key")
+			err := reconciler.removeAnnotationFromApps(ctx, apps, "key")
 			Expect(err).To(BeNil())
 			Eventually(func() int { return len(appOne.Annotations) }).Should(Equal(1))
 			Eventually(func() int { return len(appTwo.Annotations) }).Should(Equal(1))
@@ -719,7 +719,7 @@ func TestSync(t *testing.T) {
 
 	testAppName := "foo-bar"
 
-	application, error := r.syncApp(testAppName)
+	application, error := r.syncApp(ctx, testAppName)
 
 	g := NewWithT(t)
 	g.Expect(error).To(BeNil())
@@ -733,7 +733,7 @@ func TestSyncErr(t *testing.T) {
 
 	testAppName := "foo-bar"
 
-	application, error := r.syncApp(testAppName)
+	application, error := r.syncApp(ctx, testAppName)
 
 	g := NewWithT(t)
 	g.Expect(application).To(BeNil())


### PR DESCRIPTION
Fixes #67.

Two questions:
- I haven't touched `requestsForApplicationChange` nor `requestsForSecretChange` as they are called in `handler.EnqueueRequestsFromMapFunc(r.requestsForApplicationChange)` and `handler.EnqueueRequestsFromMapFunc(r.requestsForSecretChange)` respectively. Should we?
- I'm reusing the global `ctx` in tests - is there any better approach?