### PR TITLE
Release a new chart version

### DIFF
--- a/charts/applicationset-progressive-sync/Chart.yaml
+++ b/charts/applicationset-progressive-sync/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5-prealpha
+version: 0.2.0-prealpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
The crd definition has been renamed in #84 so we need to package a new chart that can install the correct crd definitions.