### PR TITLE
Fix release process

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,24 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'documentation'
+      - 'bug'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
 template: |
   ## What’s Changed
 

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -3,36 +3,35 @@ name: Release Artifacts
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
-  release:
-    name: release
+  build:
+    name: release-artifacts
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.15
+      - uses: actions/checkout@v2.3.4
 
-    - name: Check out code
-      uses: actions/checkout@v2.3.4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            maruina/applicationset-progressive-sync
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=tag
+            type=sha
 
-    - name: Get tools
-      run: make tools
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Get tag
-      uses: olegtarasov/get-tag@v2.1
-      id: tagName
-
-    - name: Login to GitHub Packages Docker Registry
-      uses: docker/login-action@v1.9.0
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Build and publish a tagged docker image
-      uses: docker/build-push-action@v2.5.0
-      with:
-        push: true
-        tags: maruina/applicationset-progressive-sync:${{ steps.tagName.outputs.tag }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  build:
+  release:
     name: release-artifacts
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Looking at the `Release Artifacts` it hasn't been running for a while. This PR:
- replace a third-party action with the docker one to extract metadata for tags. You can see it in action here: https://github.com/users/maruina/packages/container/package/docker-withings-sync (see `Recent tagged image versions`)
- use the git tag for the docker tag
- improve the release drafter template to leverage our issue labels