### PR TITLE
Revert "Update release-artifacts.yaml (#101)"

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -1,9 +1,9 @@
 name: Release Artifacts
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   release:


### PR DESCRIPTION
This reverts commit 0f054d603ec7a7606ad519689179d65729fad5c4.

Because of https://github.com/release-drafter/release-drafter/issues/876, the release drafter releases don't trigger the `push` event for GitHub. We tried to change it to trigger on `release` events, but then no tags are pushed, because it relies on `meta` information that seemingly doesn't exist for this event type (see https://github.com/Skyscanner/applicationset-progressive-sync/blob/main/.github/workflows/release-artifacts.yaml#L36).

I'm reverting for now so we can push the tag manually, we'll investigate it later.