### PR TITLE
Trigger image release on release being published

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -1,9 +1,8 @@
 name: Release Artifacts
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   release:
@@ -34,5 +33,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
We got releases working off manual tags in #107, now let us try to restore the functionality of #101 which should allow us to get a new tagged image once release drafter has published the release.
