### PR TITLE
Add update and patch to the permissions

### DIFF
--- a/charts/applicationset-progressive-sync/Chart.yaml
+++ b/charts/applicationset-progressive-sync/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0-prealpha
+version: 0.2.1-prealpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/applicationset-progressive-sync/templates/rbac.yaml
+++ b/charts/applicationset-progressive-sync/templates/rbac.yaml
@@ -21,6 +21,8 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
 - apiGroups:
   - argoproj.io
   resources:


### PR DESCRIPTION
Ref: Adding `update` and `patch` permissions to allow us to add the syncedAt annotation to the application object.