### PR TITLE
Use chart version that doesn't exist

### DIFF
--- a/charts/applicationset-progressive-sync/Chart.yaml
+++ b/charts/applicationset-progressive-sync/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1-prealpha
+version: 0.2.2-prealpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Use chart version which is not present here: https://api.github.com/repos/Skyscanner/applicationset-progressive-sync/releases.

Background: At the moment, we seem to release a new chart using the latest tag on the repo, which is not good. I will add a task to fix this. For now, we can just use a chart number which doesn't exist yet.