### PR TITLE
Fix flaky CI with a complex test case

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -38,16 +38,29 @@ jobs:
       - name: Build
         run: make manager
 
-      - name: Login to GitHub Packages Docker Registry
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/skyscanner/applicationset-progressive-sync
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=pr
+            type=semver,pattern={{raw}}
+            type=sha
+
+      - name: Login to GitHub Packages
         uses: docker/login-action@v1.9.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: github.event_name != 'pull_request'
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish a docker image when merge in main
+      - name: Build and publish a docker image
         uses: docker/build-push-action@v2.5.0
         with:
           push: true
-          tags: maruina/applicationset-progressive-sync:main
-        if: github.event_name != 'pull_request'
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint: fmt vet
 
 # Run tests
 test: tools generate fmt vet manifests
-	ginkgo -r --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress
+	ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress
 
 # Build manager binary
 manager: generate fmt vet

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint: fmt vet
 
 # Run tests
 test: tools generate fmt vet manifests
-	ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress
+	ginkgo -r --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress
 
 # Build manager binary
 manager: generate fmt vet

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint: fmt vet
 
 # Run tests
 test: tools generate fmt vet manifests
-	ginkgo -r --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress
+	ginkgo -reportPassed -r --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress
 
 # Build manager binary
 manager: generate fmt vet

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint: fmt vet
 
 # Run tests
 test: tools generate fmt vet manifests
-	ginkgo -reportPassed -r --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress
+	ginkgo -r --failOnPending --cover -coverprofile=../coverage.out --trace --race --progress
 
 # Build manager binary
 manager: generate fmt vet

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -371,7 +371,6 @@ func (r *ProgressiveSyncReconciler) setSyncedAtAnnotation(ctx context.Context, a
 		}
 		return nil
 	})
-	log.Info("failed to add syncedAt annotation because of a retryErr")
 	return retryErr
 }
 

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -62,7 +62,7 @@ type ProgressiveSyncReconciler struct {
 // Reconcile performs the reconciling for a single named ProgressiveSync object
 func (r *ProgressiveSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("progressivesync", req.NamespacedName)
-	log.Info("Starting reconciliation loop")
+	log.Info("reconciliation loop started")
 
 	// Get the ProgressiveSync object
 	var ps syncv1alpha1.ProgressiveSync
@@ -362,7 +362,7 @@ func (r *ProgressiveSyncReconciler) setSyncedAtAnnotation(ctx context.Context, a
 
 // reconcileStage reconcile a ProgressiveSyncStage
 func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv1alpha1.ProgressiveSync, stage syncv1alpha1.ProgressiveSyncStage) (syncv1alpha1.ProgressiveSync, reconcile.Result, error) {
-	log := r.Log.WithValues("progressivesync", fmt.Sprintf("%s/%s", ps.Name, ps.Namespace), "applicationset", ps.Spec.SourceRef.Name, "stage", stage.Name)
+	log := r.Log.WithValues("progressivesync", fmt.Sprintf("%s/%s", ps.Namespace, ps.Name), "applicationset", ps.Spec.SourceRef.Name, "stage", stage.Name)
 	requeueDelayOnError := time.Minute * 5
 
 	// Get the clusters to update
@@ -455,6 +455,10 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 	if scheduler.IsStageInProgress(apps, stage) {
 		message := fmt.Sprintf("%s stage in progress", stage.Name)
 		log.Info(message)
+
+		for _, app := range apps {
+			log.Info("application details", "app", app.Name, "sync.status", app.Status.Sync.Status, "health.status", app.Status.Health.Status)
+		}
 
 		r.updateStageStatus(ctx, stage.Name, message, syncv1alpha1.PhaseProgressing, &ps)
 

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Skyscanner/applicationset-progressive-sync/internal/utils"
 	applicationpkg "github.com/argoproj/argo-cd/pkg/apiclient/application"
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/gitops-engine/pkg/health"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -413,19 +412,19 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 	// Remove the annotation from the Healthy and OutOfSync Apps before passing them to the Scheduler.
 	// Healthy and OutOfSync apps are applications that have not been synced at this run of the Progressive Sync.
 	// This action allows the Scheduler to keep track at which stage an Application has been synced.
-	outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
-	healthyApps := utils.GetAppsByHealthStatusCode(outOfSyncApps, health.HealthStatusHealthy)
-	if err := r.removeAnnotationFromApps(ctx, healthyApps, utils.ProgressiveSyncSyncedAtStageKey); err != nil {
-		message := "failed to remove out-of-sync annotation from apps"
-		log.Error(err, message)
-
-		r.updateStageStatus(ctx, stage.Name, message, syncv1alpha1.PhaseFailed, &ps)
-		// Set ProgressiveSync status
-		failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
-		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
-
-		return ps, ctrl.Result{}, err
-	}
+	//outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
+	//healthyApps := utils.GetAppsByHealthStatusCode(outOfSyncApps, health.HealthStatusHealthy)
+	//if err := r.removeAnnotationFromApps(ctx, healthyApps, utils.ProgressiveSyncSyncedAtStageKey); err != nil {
+	//	message := "failed to remove out-of-sync annotation from apps"
+	//	log.Error(err, message)
+	//
+	//	r.updateStageStatus(ctx, stage.Name, message, syncv1alpha1.PhaseFailed, &ps)
+	//	// Set ProgressiveSync status
+	//	failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
+	//	apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
+	//
+	//	return ps, ctrl.Result{}, err
+	//}
 
 	// Get the Applications to update
 	scheduledApps := scheduler.Scheduler(apps, stage)

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -98,7 +98,7 @@ func (r *ProgressiveSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	for _, stage := range ps.Spec.Stages {
 		log = log.WithValues("stage", stage.Name)
 
-		ps, result, reconcileErr, exitReconcile := r.reconcileStage(ctx, ps, stage)
+		ps, result, reconcileErr := r.reconcileStage(ctx, ps, stage)
 		if err := r.updateStatusWithRetry(ctx, &ps); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -108,10 +108,6 @@ func (r *ProgressiveSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return result, reconcileErr
 		}
 
-		// If there is an error and we don't want to move to the next stage
-		if exitReconcile {
-			return result, nil
-		}
 	}
 
 	// Progressive rollout completed
@@ -365,9 +361,9 @@ func (r *ProgressiveSyncReconciler) setSyncedAtAnnotation(ctx context.Context, a
 }
 
 // reconcileStage reconcile a ProgressiveSyncStage
-func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv1alpha1.ProgressiveSync, stage syncv1alpha1.ProgressiveSyncStage) (syncv1alpha1.ProgressiveSync, reconcile.Result, error, bool) {
+func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv1alpha1.ProgressiveSync, stage syncv1alpha1.ProgressiveSyncStage) (syncv1alpha1.ProgressiveSync, reconcile.Result, error) {
 	log := r.Log.WithValues("progressivesync", fmt.Sprintf("%s/%s", ps.Name, ps.Namespace), "applicationset", ps.Spec.SourceRef.Name, "stage", stage.Name)
-	exitReconcile := false
+	requeueDelayOnError := time.Minute * 5
 
 	// Get the clusters to update
 	clusters, err := r.getClustersFromSelector(ctx, stage.Targets.Clusters.Selector)
@@ -381,7 +377,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
 
-		return ps, ctrl.Result{}, err, exitReconcile
+		return ps, ctrl.Result{RequeueAfter: requeueDelayOnError}, err
 	}
 	log.Info("fetched clusters using label selector", "clusters", utils.GetClustersName(clusters.Items))
 
@@ -394,7 +390,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		r.updateStageStatus(ctx, stage.Name, message, syncv1alpha1.PhaseFailed, &ps)
 		failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
-		return ps, ctrl.Result{}, err, exitReconcile
+		return ps, ctrl.Result{RequeueAfter: requeueDelayOnError}, err
 	}
 	log.Info("fetched apps targeting selected clusters", "apps", utils.GetAppsName(apps))
 
@@ -430,7 +426,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 				// Set ProgressiveSync status
 				failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
 				apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
-				return ps, ctrl.Result{}, err, exitReconcile
+				return ps, ctrl.Result{RequeueAfter: requeueDelayOnError}, err
 			}
 		}
 
@@ -439,7 +435,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 			message := "failed to add syncedAt annotation"
 			log.Error(err, message, "message", err.Error())
 
-			return ps, ctrl.Result{}, err, exitReconcile
+			return ps, ctrl.Result{RequeueAfter: requeueDelayOnError}, err
 		}
 	}
 
@@ -453,9 +449,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
 
 		log.Info("sync failed")
-		// We can set Requeue: true once we have a timeout in place
-		exitReconcile = true
-		return ps, ctrl.Result{}, nil, exitReconcile
+		return ps, ctrl.Result{RequeueAfter: requeueDelayOnError}, err
 	}
 
 	if scheduler.IsStageInProgress(apps, stage) {
@@ -468,7 +462,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), progress)
 
 		// Stage in progress, we reconcile again until the stage is completed or failed
-		return ps, ctrl.Result{Requeue: true}, nil, exitReconcile
+		return ps, ctrl.Result{Requeue: true}, nil
 	}
 
 	if scheduler.IsStageComplete(apps, stage) {
@@ -480,9 +474,9 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		progress := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesProgressingReason, message)
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), progress)
 
-		return ps, ctrl.Result{}, nil, exitReconcile
+		return ps, ctrl.Result{}, nil
 
 	}
 
-	return ps, ctrl.Result{Requeue: true}, nil, exitReconcile
+	return ps, ctrl.Result{Requeue: true}, nil
 }

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -394,7 +394,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 	for _, s := range scheduledApps {
 		log.Info("syncing app", "app", fmt.Sprintf("%s/%s", s.Namespace, s.Name), "sync.status", s.Status.Sync.Status, "health.status", s.Status.Health.Status)
 
-		_, err = r.syncApp(ctx, s.Name)
+		_, err := r.syncApp(ctx, s.Name)
 
 		if err != nil {
 			if !strings.Contains(err.Error(), "another operation is already in progress") {
@@ -410,7 +410,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 			log.Info("failed to sync app because it is already syncing")
 		}
 
-		err := r.setSyncedAtAnnotation(ctx, s, stage.Name)
+		err = r.setSyncedAtAnnotation(ctx, s, stage.Name)
 		if err != nil {
 			message := "failed at setSyncedAtAnnotation"
 			log.Error(err, message, "message", err.Error())

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -428,7 +428,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
 
 		log.Info("sync failed")
-		return ps, ctrl.Result{RequeueAfter: requeueDelayOnError}, err
+		return ps, ctrl.Result{Requeue: true, RequeueAfter: requeueDelayOnError}, nil
 	}
 
 	if scheduler.IsStageInProgress(apps, stage) {

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -450,7 +450,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		return ps, ctrl.Result{}, nil
 	}
 
-	if scheduler.IsStageInProgress(apps) {
+	if scheduler.IsStageInProgress(apps, stage) {
 		message := fmt.Sprintf("%s stage in progress", stage.Name)
 		log.Info(message)
 

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -360,7 +360,7 @@ func (r *ProgressiveSyncReconciler) setSyncedAtAnnotation(ctx context.Context, a
 
 // reconcileStage reconcile a ProgressiveSyncStage
 func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv1alpha1.ProgressiveSync, stage syncv1alpha1.ProgressiveSyncStage) (syncv1alpha1.ProgressiveSync, reconcile.Result, error) {
-	log := r.Log.WithValues("stage", stage.Name)
+	log := r.Log.WithValues("stage", stage.Name).WithValues("progressivesync", ps.Name)
 
 	// Get the clusters to update
 	clusters, err := r.getClustersFromSelector(ctx, stage.Targets.Clusters.Selector)

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -361,7 +361,7 @@ func (r *ProgressiveSyncReconciler) setSyncedAtAnnotation(ctx context.Context, a
 
 // reconcileStage reconcile a ProgressiveSyncStage
 func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv1alpha1.ProgressiveSync, stage syncv1alpha1.ProgressiveSyncStage) (syncv1alpha1.ProgressiveSync, reconcile.Result, error) {
-	log := r.Log.WithValues("progressivesync", ps.Name, "applicationset", ps.Spec.SourceRef.Name, "stage", stage.Name)
+	log := r.Log.WithValues("progressivesync", fmt.Sprintf("%s/%s", ps.Name, ps.Namespace), "applicationset", ps.Spec.SourceRef.Name, "stage", stage.Name)
 
 	// Get the clusters to update
 	clusters, err := r.getClustersFromSelector(ctx, stage.Targets.Clusters.Selector)

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -393,18 +393,18 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 
 	// Remove the annotation from the OutOfSync Applications before passing them to the Scheduler
 	// This action allows the Scheduler to keep track at which stage an Application has been synced.
-	outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
-	if err := r.removeAnnotationFromApps(ctx, outOfSyncApps, utils.ProgressiveSyncSyncedAtStageKey); err != nil {
-		message := "failed to remove out-of-sync annotation from apps"
-		log.Error(err, message)
+	// outOfSyncApps := utils.GetAppsBySyncStatusCode(apps, argov1alpha1.SyncStatusCodeOutOfSync)
+	// if err := r.removeAnnotationFromApps(ctx, outOfSyncApps, utils.ProgressiveSyncSyncedAtStageKey); err != nil {
+	// 	message := "failed to remove out-of-sync annotation from apps"
+	// 	log.Error(err, message)
 
-		r.updateStageStatus(ctx, stage.Name, message, syncv1alpha1.PhaseFailed, &ps)
-		// Set ProgressiveSync status
-		failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
-		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
+	// 	r.updateStageStatus(ctx, stage.Name, message, syncv1alpha1.PhaseFailed, &ps)
+	// 	// Set ProgressiveSync status
+	// 	failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
+	// 	apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
 
-		return ps, ctrl.Result{}, err
-	}
+	// 	return ps, ctrl.Result{}, err
+	// }
 
 	// Get the Applications to update
 	scheduledApps := scheduler.Scheduler(apps, stage)

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -361,7 +361,7 @@ func (r *ProgressiveSyncReconciler) setSyncedAtAnnotation(ctx context.Context, a
 
 // reconcileStage reconcile a ProgressiveSyncStage
 func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv1alpha1.ProgressiveSync, stage syncv1alpha1.ProgressiveSyncStage) (syncv1alpha1.ProgressiveSync, reconcile.Result, error) {
-	log := logr.FromContext(ctx)
+	log := r.Log.WithValues("progressivesync", ps.Name, "applicationset", ps.Spec.SourceRef.Name, "stage", stage.Name)
 
 	// Get the clusters to update
 	clusters, err := r.getClustersFromSelector(ctx, stage.Targets.Clusters.Selector)

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -376,7 +376,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 
 		return ps, ctrl.Result{}, err
 	}
-	log.Info("clusters selected", "clusters", utils.GetClustersName(clusters.Items))
+	log.Info("fetched clusters using label selector", "clusters", utils.GetClustersName(clusters.Items))
 
 	// Get only the Applications owned by the ProgressiveSync targeting the selected clusters
 	apps, err := r.getOwnedAppsFromClusters(ctx, clusters, &ps)
@@ -389,7 +389,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
 		return ps, ctrl.Result{}, err
 	}
-	log.Info("apps selected", "apps", utils.GetAppsName(apps))
+	log.Info("fetched apps targeting selected clusters", "apps", utils.GetAppsName(apps))
 
 	// Remove the annotation from the OutOfSync Applications before passing them to the Scheduler
 	// This action allows the Scheduler to keep track at which stage an Application has been synced.
@@ -410,7 +410,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 	scheduledApps := scheduler.Scheduler(apps, stage)
 
 	for _, s := range scheduledApps {
-		log.Info("syncing app", "app", s)
+		log.Info("syncing app", "app", s.Name, "sync.status", s.Status.Sync.Status, "health.status", s.Status.Health.Status)
 
 		_, err := r.syncApp(ctx, s.Name)
 

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -369,7 +369,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
 
-		return ps, ctrl.Result{RequeueAfter: requeueDelayOnError}, err
+		return ps, ctrl.Result{Requeue: true, RequeueAfter: requeueDelayOnError}, err
 	}
 	log.Info("fetched clusters using label selector", "clusters", utils.GetClustersName(clusters.Items))
 
@@ -382,7 +382,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 		r.updateStageStatus(ctx, stage.Name, message, syncv1alpha1.PhaseFailed, &ps)
 		failed := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, message)
 		apimeta.SetStatusCondition(ps.GetStatusConditions(), failed)
-		return ps, ctrl.Result{RequeueAfter: requeueDelayOnError}, err
+		return ps, ctrl.Result{Requeue: true, RequeueAfter: requeueDelayOnError}, err
 	}
 	log.Info("fetched apps targeting selected clusters", "apps", utils.GetAppsName(apps))
 

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -418,7 +418,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 
 	}
 
-	if scheduler.IsStageFailed(apps) {
+	if scheduler.IsStageFailed(apps, stage) {
 		message := fmt.Sprintf("%s stage failed", stage.Name)
 		log.Info(message)
 

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -334,7 +334,7 @@ func (r *ProgressiveSyncReconciler) setSyncedAtAnnotation(ctx context.Context, a
 			return err
 		}
 
-		log = log.WithValues("app", fmt.Sprintf("%s/%s", app.Namespace, app.Name))
+		log = log.WithValues("app", fmt.Sprintf("%s/%s", latest.Namespace, latest.Name))
 
 		if latest.Annotations == nil {
 			latest.Annotations = map[string]string{

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -418,7 +418,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 	//}
 
 	// Get the Applications to update
-	scheduledApps := scheduler.Scheduler(apps, stage)
+	scheduledApps := scheduler.Scheduler(log, apps, stage)
 
 	for _, s := range scheduledApps {
 		log.Info("syncing app", "app", fmt.Sprintf("%s/%s", s.Namespace, s.Name), "sync.status", s.Status.Sync.Status, "health.status", s.Status.Health.Status)

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -349,26 +349,18 @@ func (r *ProgressiveSyncReconciler) setSyncedAtAnnotation(ctx context.Context, a
 
 		log = log.WithValues("app", fmt.Sprintf("%s/%s", app.Namespace, app.Name))
 
-		val, ok := app.Annotations[utils.ProgressiveSyncSyncedAtStageKey]
-
-		// Required due to the use of `omitempty` in serialisation.
-		// `omitempty` converts the empty map into nil.
-		if !ok {
-			if latest.Annotations == nil {
-				log.Info("create empty annotations object")
-				latest.Annotations = make(map[string]string)
-			} else {
-				log.Info("set syncedAt annotation because key was missing")
-				latest.Annotations[utils.ProgressiveSyncSyncedAtStageKey] = stageName
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{
+				utils.ProgressiveSyncSyncedAtStageKey: stageName,
 			}
-		}
-		if val != stageName {
-			log.Info("set syncedAt annotation because of wrong value")
+		} else {
 			latest.Annotations[utils.ProgressiveSyncSyncedAtStageKey] = stageName
 		}
+
 		if err := r.Client.Update(ctx, &latest); err != nil {
 			return err
 		}
+		log.Info("app annotated")
 		return nil
 	})
 	return retryErr

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 20
+	timeout  = time.Second * 30
 	interval = time.Millisecond * 10
 )
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -242,43 +242,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 		})
 	})
 
-	Describe("removeAnnotationFromApps function", func() {
-		It("should remove the target annotation from the given apps", func() {
-			By("creating two applications with two annotations")
-			appOne := argov1alpha1.Application{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-one",
-					Namespace: namespace,
-					Annotations: map[string]string{
-						"foo": "bar",
-						"key": "value",
-					},
-				},
-				Spec: argov1alpha1.ApplicationSpec{},
-			}
-			Expect(k8sClient.Create(ctx, &appOne)).To(Succeed())
-
-			appTwo := argov1alpha1.Application{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-two",
-					Namespace: namespace,
-					Annotations: map[string]string{
-						"bob": "alice",
-						"key": "value",
-					},
-				},
-				Spec: argov1alpha1.ApplicationSpec{},
-			}
-			Expect(k8sClient.Create(ctx, &appTwo)).To(Succeed())
-
-			apps := []argov1alpha1.Application{appOne, appTwo}
-			err := reconciler.removeAnnotationFromApps(ctx, apps, "key")
-			Expect(err).To(BeNil())
-			Eventually(func() int { return len(appOne.Annotations) }).Should(Equal(1))
-			Eventually(func() int { return len(appTwo.Annotations) }).Should(Equal(1))
-		})
-	})
-
 	Describe("reconciliation loop", func() {
 		It("should reconcile a multi-stage progressive sync", func() {
 			testPrefix := "multi"

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -723,6 +723,8 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			// Make sure the ProgressiveSync is completed
 			expected := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionTrue, syncv1alpha1.StagesCompleteReason, "All stages completed")
 			ExpectCondition(&ps, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
+
+			Expect(k8sClient.Delete(ctx, &ps)).To(Succeed())
 		})
 
 		//It("should fail if unable to sync an application", func() {

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 60
+	timeout  = time.Second * 120
 	interval = time.Millisecond * 10
 )
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -478,6 +478,31 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return setAppStatusProgressing(ctx, "account3-ap-southeast-1a-1", namespace)
 			}).Should(Succeed())
 
+			// Make sure the annotation is added
+			Eventually(func() bool {
+				return hasAnnotation(
+					"account2-eu-central-1a-1",
+					namespace,
+					utils.ProgressiveSyncSyncedAtStageKey,
+					"one cluster as canary in every other region")
+			}).Should(BeTrue())
+
+			Eventually(func() bool {
+				return hasAnnotation(
+					"account2-eu-central-1b-1",
+					namespace,
+					utils.ProgressiveSyncSyncedAtStageKey,
+					"one cluster as canary in every other region")
+			}).Should(BeTrue())
+
+			Eventually(func() bool {
+				return hasAnnotation(
+					"account3-ap-southeast-1a-1",
+					namespace,
+					utils.ProgressiveSyncSyncedAtStageKey,
+					"one cluster as canary in every other region")
+			}).Should(BeTrue())
+
 			// Make sure the previous stage is still completed
 			// TODO: we probably need to check that startedAt and finishedAt didn't change
 			ExpectStageStatus(ctx, psKey, "one cluster as canary in eu-west-1").Should(MatchStage(syncv1alpha1.StageStatus{
@@ -535,6 +560,15 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return setAppStatusProgressing(ctx, "account1-eu-west-1a-2", namespace)
 			}).Should(Succeed())
 
+			// Make sure the annotation is added
+			Eventually(func() bool {
+				return hasAnnotation(
+					"account1-eu-west-1a-2",
+					namespace,
+					utils.ProgressiveSyncSyncedAtStageKey,
+					"rollout to remaining clusters")
+			}).Should(BeTrue())
+
 			// Make sure the current stage is progressing
 			message = "rollout to remaining clusters stage in progress"
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{
@@ -569,6 +603,15 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return setAppStatusProgressing(ctx, "account3-ap-southeast-1c-1", namespace)
 			}).Should(Succeed())
 
+			// Make sure the annotation is added
+			Eventually(func() bool {
+				return hasAnnotation(
+					"account3-ap-southeast-1c-1",
+					namespace,
+					utils.ProgressiveSyncSyncedAtStageKey,
+					"rollout to remaining clusters")
+			}).Should(BeTrue())
+
 			// Make sure the current stage is progressing
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{
 				Name:    "rollout to remaining clusters",
@@ -602,6 +645,15 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 				return setAppStatusProgressing(ctx, "account4-ap-northeast-1a-1", namespace)
 			}).Should(Succeed())
 
+			// Make sure the annotation is added
+			Eventually(func() bool {
+				return hasAnnotation(
+					"account4-ap-northeast-1a-1",
+					namespace,
+					utils.ProgressiveSyncSyncedAtStageKey,
+					"rollout to remaining clusters")
+			}).Should(BeTrue())
+
 			// Make sure the current stage is progressing
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{
 				Name:    "rollout to remaining clusters",
@@ -634,6 +686,15 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Eventually(func() error {
 				return setAppStatusProgressing(ctx, "account4-ap-northeast-1a-2", namespace)
 			}).Should(Succeed())
+
+			// Make sure the annotation is added
+			Eventually(func() bool {
+				return hasAnnotation(
+					"account4-ap-northeast-1a-2",
+					namespace,
+					utils.ProgressiveSyncSyncedAtStageKey,
+					"rollout to remaining clusters")
+			}).Should(BeTrue())
 
 			// Make sure the current stage is progressing
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 300
+	timeout  = time.Second * 90
 	interval = time.Millisecond * 10
 )
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 30
+	timeout  = time.Second * 60
 	interval = time.Millisecond * 10
 )
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 300
+	timeout  = time.Second * 360
 	interval = time.Millisecond * 10
 )
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -330,8 +330,8 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 					},
 					Stages: []syncv1alpha1.ProgressiveSyncStage{{
 						Name:        "one cluster as canary in eu-west-1",
-						MaxParallel: intstr.IntOrString{IntVal: 1},
-						MaxTargets:  intstr.IntOrString{IntVal: 1},
+						MaxParallel: intstr.Parse("1"),
+						MaxTargets:  intstr.Parse("1"),
 						Targets: syncv1alpha1.ProgressiveSyncTargets{
 							Clusters: syncv1alpha1.Clusters{
 								Selector: metav1.LabelSelector{MatchLabels: map[string]string{
@@ -340,8 +340,8 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 							}},
 					}, {
 						Name:        "one cluster as canary in every other region",
-						MaxParallel: intstr.IntOrString{IntVal: 3},
-						MaxTargets:  intstr.IntOrString{IntVal: 3},
+						MaxParallel: intstr.Parse("3"),
+						MaxTargets:  intstr.Parse("3"),
 						Targets: syncv1alpha1.ProgressiveSyncTargets{
 							Clusters: syncv1alpha1.Clusters{
 								Selector: metav1.LabelSelector{
@@ -741,8 +741,8 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 					},
 					Stages: []syncv1alpha1.ProgressiveSyncStage{{
 						Name:        "stage 0",
-						MaxParallel: intstr.IntOrString{IntVal: 1},
-						MaxTargets:  intstr.IntOrString{IntVal: 1},
+						MaxParallel: intstr.Parse("1"),
+						MaxTargets:  intstr.Parse("1"),
 						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
 							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
 								"cluster": clusters[0].Name,
@@ -750,8 +750,8 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 						}},
 					}, {
 						Name:        "stage 1",
-						MaxParallel: intstr.IntOrString{IntVal: 1},
-						MaxTargets:  intstr.IntOrString{IntVal: 1},
+						MaxParallel: intstr.Parse("1"),
+						MaxTargets:  intstr.Parse("1"),
 						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
 							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
 								"cluster": clusters[1].Name,
@@ -844,8 +844,8 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 					},
 					Stages: []syncv1alpha1.ProgressiveSyncStage{{
 						Name:        "stage 1",
-						MaxParallel: intstr.IntOrString{IntVal: 1},
-						MaxTargets:  intstr.IntOrString{IntVal: 1},
+						MaxParallel: intstr.Parse("1"),
+						MaxTargets:  intstr.Parse("1"),
 						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
 							Selector: metav1.LabelSelector{MatchLabels: nil},
 						}},

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -651,7 +651,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 			By("completing 100% of the third stage applications")
 			Eventually(func() error {
-				return setAppStatusCompleted(ctx, "account1-eu-west-1a-2", namespace)
+				return setAppStatusCompleted(ctx, "account4-ap-northeast-1a-2", namespace)
 			}).Should(Succeed())
 
 			// Make sure the current stage is completed

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -690,101 +690,101 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Expect(k8sClient.Delete(ctx, &ps)).To(Succeed())
 		})
 
-		//It("should fail if unable to sync an application", func() {
-		//	testPrefix := "failed-stage"
-		//	appSet := fmt.Sprintf("%s-appset", testPrefix)
-		//
-		//	By("creating two ArgoCD clusters")
-		//	targets := []Target{
-		//		{
-		//			Name:           "account5-us-west-1a-1",
-		//			Namespace:      namespace,
-		//			ApplicationSet: appSet,
-		//			Area:           "na",
-		//			Region:         "us-west-1",
-		//			AZ:             "us-west-1a",
-		//		}, {
-		//			Name:           "account5-us-west-1a-2",
-		//			Namespace:      namespace,
-		//			ApplicationSet: appSet,
-		//			Area:           "na",
-		//			Region:         "us-west-1",
-		//			AZ:             "us-west-1a",
-		//		},
-		//	}
-		//	clusters, err := createClusters(ctx, targets)
-		//	Expect(err).To(BeNil())
-		//	Expect(clusters).To(Not(BeNil()))
-		//
-		//	By("creating one application targeting each cluster")
-		//	apps, err := createApplications(ctx, targets)
-		//	Expect(err).To(BeNil())
-		//	Expect(apps).To(Not(BeNil()))
-		//
-		//	By("creating a progressive sync")
-		//	failedStagePS := syncv1alpha1.ProgressiveSync{
-		//		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-ps", testPrefix), Namespace: namespace},
-		//		Spec: syncv1alpha1.ProgressiveSyncSpec{
-		//			SourceRef: corev1.TypedLocalObjectReference{
-		//				APIGroup: &appSetAPIRef,
-		//				Kind:     utils.AppSetKind,
-		//				Name:     appSet,
-		//			},
-		//			Stages: []syncv1alpha1.ProgressiveSyncStage{{
-		//				Name:        "stage 0",
-		//				MaxParallel: intstr.IntOrString{IntVal: 1},
-		//				MaxTargets:  intstr.IntOrString{IntVal: 1},
-		//				Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
-		//					Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-		//						"cluster": clusters[0].Name,
-		//					}},
-		//				}},
-		//			}, {
-		//				Name:        "stage 1",
-		//				MaxParallel: intstr.IntOrString{IntVal: 1},
-		//				MaxTargets:  intstr.IntOrString{IntVal: 1},
-		//				Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
-		//					Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-		//						"cluster": clusters[1].Name,
-		//					}},
-		//				}},
-		//			}},
-		//		},
-		//	}
-		//	Expect(k8sClient.Create(ctx, &failedStagePS)).To(Succeed())
-		//
-		//	psKey := client.ObjectKey{
-		//		Namespace: namespace,
-		//		Name:      fmt.Sprintf("%s-ps", testPrefix),
-		//	}
-		//
-		//	By("progressing the first application")
-		//	Eventually(func() error {
-		//		return setAppStatusProgressing(ctx, "account5-us-west-1a-1", namespace)
-		//	}).Should(Succeed())
-		//
-		//	ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
-		//		Name:    "stage 0",
-		//		Phase:   syncv1alpha1.PhaseProgressing,
-		//		Message: "stage 0 stage in progress",
-		//	}))
-		//	ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
-		//
-		//	By("failing syncing the first application")
-		//	Eventually(func() error {
-		//		return setAppStatusFailed(ctx, "account5-us-west-1a-1", namespace)
-		//	}).Should(Succeed())
-		//
-		//	ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
-		//		Name:    "stage 0",
-		//		Phase:   syncv1alpha1.PhaseFailed,
-		//		Message: "stage 0 stage failed",
-		//	}))
-		//	ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
-		//
-		//	expected := failedStagePS.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, "stage 0 stage failed")
-		//	ExpectCondition(&failedStagePS, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
-		//})
+		It("should fail if unable to sync an application", func() {
+			testPrefix := "failed-stage"
+			appSet := fmt.Sprintf("%s-appset", testPrefix)
+
+			By("creating two ArgoCD clusters")
+			targets := []Target{
+				{
+					Name:           "account5-us-west-1a-1",
+					Namespace:      namespace,
+					ApplicationSet: appSet,
+					Area:           "na",
+					Region:         "us-west-1",
+					AZ:             "us-west-1a",
+				}, {
+					Name:           "account5-us-west-1a-2",
+					Namespace:      namespace,
+					ApplicationSet: appSet,
+					Area:           "na",
+					Region:         "us-west-1",
+					AZ:             "us-west-1a",
+				},
+			}
+			clusters, err := createClusters(ctx, targets)
+			Expect(err).To(BeNil())
+			Expect(clusters).To(Not(BeNil()))
+
+			By("creating one application targeting each cluster")
+			apps, err := createApplications(ctx, targets)
+			Expect(err).To(BeNil())
+			Expect(apps).To(Not(BeNil()))
+
+			By("creating a progressive sync")
+			failedStagePS := syncv1alpha1.ProgressiveSync{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-ps", testPrefix), Namespace: namespace},
+				Spec: syncv1alpha1.ProgressiveSyncSpec{
+					SourceRef: corev1.TypedLocalObjectReference{
+						APIGroup: &appSetAPIRef,
+						Kind:     utils.AppSetKind,
+						Name:     appSet,
+					},
+					Stages: []syncv1alpha1.ProgressiveSyncStage{{
+						Name:        "stage 0",
+						MaxParallel: intstr.IntOrString{IntVal: 1},
+						MaxTargets:  intstr.IntOrString{IntVal: 1},
+						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+								"cluster": clusters[0].Name,
+							}},
+						}},
+					}, {
+						Name:        "stage 1",
+						MaxParallel: intstr.IntOrString{IntVal: 1},
+						MaxTargets:  intstr.IntOrString{IntVal: 1},
+						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+								"cluster": clusters[1].Name,
+							}},
+						}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &failedStagePS)).To(Succeed())
+
+			psKey := client.ObjectKey{
+				Namespace: namespace,
+				Name:      fmt.Sprintf("%s-ps", testPrefix),
+			}
+
+			By("progressing the first application")
+			Eventually(func() error {
+				return setAppStatusProgressing(ctx, "account5-us-west-1a-1", namespace)
+			}).Should(Succeed())
+
+			ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
+				Name:    "stage 0",
+				Phase:   syncv1alpha1.PhaseProgressing,
+				Message: "stage 0 stage in progress",
+			}))
+			ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
+
+			By("failing syncing the first application")
+			Eventually(func() error {
+				return setAppStatusFailed(ctx, "account5-us-west-1a-1", namespace)
+			}).Should(Succeed())
+
+			ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
+				Name:    "stage 0",
+				Phase:   syncv1alpha1.PhaseFailed,
+				Message: "stage 0 stage failed",
+			}))
+			ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
+
+			expected := failedStagePS.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, "stage 0 stage failed")
+			ExpectCondition(&failedStagePS, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
+		})
 	})
 
 	Describe("sync application", func() {
@@ -973,27 +973,27 @@ func setAppStatusCompleted(ctx context.Context, appName string, namespace string
 }
 
 // setAppStatusFailed set the application health status to failed given an application name and its namespace
-//func setAppStatusFailed(ctx context.Context, appName string, namespace string) error {
-//	app := argov1alpha1.Application{}
-//	err := k8sClient.Get(ctx, client.ObjectKey{
-//		Namespace: namespace,
-//		Name:      appName,
-//	}, &app)
-//
-//	if err != nil {
-//		return err
-//	}
-//
-//	app.Status.Health = argov1alpha1.HealthStatus{
-//		Status:  health.HealthStatusDegraded,
-//		Message: "degraded",
-//	}
-//	app.Status.Sync = argov1alpha1.SyncStatus{
-//		Status: argov1alpha1.SyncStatusCodeSynced,
-//	}
-//
-//	return k8sClient.Update(ctx, &app)
-//}
+func setAppStatusFailed(ctx context.Context, appName string, namespace string) error {
+	app := argov1alpha1.Application{}
+	err := k8sClient.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      appName,
+	}, &app)
+
+	if err != nil {
+		return err
+	}
+
+	app.Status.Health = argov1alpha1.HealthStatus{
+		Status:  health.HealthStatusDegraded,
+		Message: "degraded",
+	}
+	app.Status.Sync = argov1alpha1.SyncStatus{
+		Status: argov1alpha1.SyncStatusCodeSynced,
+	}
+
+	return k8sClient.Update(ctx, &app)
+}
 
 // hasAnnotation returns true if the application has an annotation with the given key and value
 func hasAnnotation(appName, namespace, key, value string) bool {

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -35,6 +35,7 @@ var (
 	ctx          = context.Background()
 )
 
+// Target is an helper structure that holds the information to create clusters and applications
 type Target struct {
 	Name           string
 	Namespace      string

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -44,6 +44,16 @@ type Target struct {
 	AZ             string
 }
 
+func createRandomNamespace() (string, *corev1.Namespace) {
+	namespace := "progressiverollout-test-" + randStringNumber(5)
+
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}
+	Expect(k8sClient.Create(ctx, &ns)).To(Succeed())
+	return namespace, &ns
+}
+
 func createOwnerPR(ns string, owner string) *syncv1alpha1.ProgressiveSync {
 	return &syncv1alpha1.ProgressiveSync{
 		ObjectMeta: metav1.ObjectMeta{Name: owner, Namespace: ns},
@@ -64,6 +74,19 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 	SetDefaultEventuallyTimeout(timeout)
 	SetDefaultEventuallyPollingInterval(interval)
 	format.TruncatedDiff = false
+
+	var (
+		namespace string
+		ns        *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		namespace, ns = createRandomNamespace()
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+	})
 
 	Describe("requestsForApplicationChange function", func() {
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -353,9 +353,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 								},
 							}},
 					}, {
-						Name: "rollout to remaining clusters",
-						// MaxParallel: intstr.Parse("25%"),
-						// MaxTargets:  intstr.Parse("100%"),
+						Name:        "rollout to remaining clusters",
 						MaxParallel: intstr.Parse("1"),
 						MaxTargets:  intstr.Parse("4"),
 						Targets: syncv1alpha1.ProgressiveSyncTargets{
@@ -687,7 +685,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			expected := ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionTrue, syncv1alpha1.StagesCompleteReason, "All stages completed")
 			ExpectCondition(&ps, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
 
-			Expect(k8sClient.Delete(ctx, &ps)).To(Succeed())
 		})
 
 		It("should fail if unable to sync an application", func() {

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -625,7 +625,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 			By("completing 100% of the third stage applications")
 			Eventually(func() error {
-				return setAppStatusCompleted(ctx, "account1-ap-northeast-1a-2", namespace)
+				return setAppStatusCompleted(ctx, "account4-ap-northeast-1a-2", namespace)
 			}).Should(Succeed())
 
 			// Make sure the current stage is completed

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -725,115 +725,101 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			ExpectCondition(&ps, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
 		})
 
-		//It("should fail if unable to sync application", func() {
-		//	testPrefix := "failed-stages"
-		//	appSet := fmt.Sprintf("%s-appset", testPrefix)
-		//
-		//	By("creating two ArgoCD clusters")
-		//	targets := []Target{
-		//		{
-		//			Name:           "account7-eu-west-1a-1",
-		//			Namespace:      namespace,
-		//			ApplicationSet: appSet,
-		//			Area:           "emea",
-		//			Region:         "eu-west-1",
-		//			AZ:             "eu-west-1a",
-		//		}, {
-		//			Name:           "account7-eu-west-1a-2",
-		//			Namespace:      namespace,
-		//			ApplicationSet: appSet,
-		//			Area:           "emea",
-		//			Region:         "eu-west-1",
-		//			AZ:             "eu-west-1a",
-		//		},
-		//	}
-		//	clusters, err := createClusters(ctx, targets)
-		//	Expect(err).To(BeNil())
-		//	Expect(clusters).To(Not(BeNil()))
-		//
-		//	By("creating one application targeting each cluster")
-		//	apps, err := createApplications(ctx, targets)
-		//	Expect(err).To(BeNil())
-		//	Expect(apps).To(Not(BeNil()))
-		//
-		//	By("creating a progressive sync")
-		//	failedStagePR := syncv1alpha1.ProgressiveSync{
-		//		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-ps", testPrefix), Namespace: namespace},
-		//		Spec: syncv1alpha1.ProgressiveSyncSpec{
-		//			SourceRef: corev1.TypedLocalObjectReference{
-		//				APIGroup: &appSetAPIRef,
-		//				Kind:     utils.AppSetKind,
-		//				Name:     appSet,
-		//			},
-		//			Stages: []syncv1alpha1.ProgressiveSyncStage{{
-		//				Name:        "stage 0",
-		//				MaxParallel: intstr.IntOrString{IntVal: 1},
-		//				MaxTargets:  intstr.IntOrString{IntVal: 1},
-		//				Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
-		//					Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-		//						"cluster": clusters[0].Name,
-		//					}},
-		//				}},
-		//			}, {
-		//				Name:        "stage 1",
-		//				MaxParallel: intstr.IntOrString{IntVal: 1},
-		//				MaxTargets:  intstr.IntOrString{IntVal: 1},
-		//				Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
-		//					Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-		//						"cluster": clusters[1].Name,
-		//					}},
-		//				}},
-		//			}},
-		//		},
-		//	}
-		//	Expect(k8sClient.Create(ctx, &failedStagePR)).To(Succeed())
-		//
-		//	psKey := client.ObjectKey{
-		//		Namespace: namespace,
-		//		Name:      fmt.Sprintf("%s-ps", testPrefix),
-		//	}
-		//
-		//	By("progressing in first application")
-		//	Eventually(func() error {
-		//		return setAppStatusProgressing(ctx, "account7-eu-west-1a-1", namespace)
-		//	}).Should(Succeed())
-		//
-		//	ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
-		//		Name:    "stage 0",
-		//		Phase:   syncv1alpha1.PhaseProgressing,
-		//		Message: "stage 0 stage in progress",
-		//	}))
-		//	ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
-		//
-		//	By("failed syncing first application")
-		//	Eventually(func() error {
-		//		return setAppStatusFailed(ctx, "account7-eu-west-1a-1", namespace)
-		//	}).Should(Succeed())
-		//
-		//	ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
-		//		Name:    "stage 0",
-		//		Phase:   syncv1alpha1.PhaseFailed,
-		//		Message: "stage 0 stage failed",
-		//	}))
-		//	ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
-		//
-		//	createdPR := syncv1alpha1.ProgressiveSync{}
-		//	Eventually(func() int {
-		//		_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &createdPR)
-		//		return len(createdPR.ObjectMeta.Finalizers)
-		//	}).Should(Equal(1))
-		//	Expect(createdPR.ObjectMeta.Finalizers[0]).To(Equal(syncv1alpha1.ProgressiveSyncFinalizer))
-		//
-		//	expected := failedStagePR.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, "stage 0 stage failed")
-		//	ExpectCondition(&failedStagePR, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
-		//
-		//	deletedPR := syncv1alpha1.ProgressiveSync{}
-		//	Expect(k8sClient.Delete(ctx, &failedStagePR)).To(Succeed())
-		//	Eventually(func() error {
-		//		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &deletedPR)
-		//		return err
-		//	}).Should(HaveOccurred())
-		//})
+		It("should fail if unable to sync an application", func() {
+			testPrefix := "failed-stage"
+			appSet := fmt.Sprintf("%s-appset", testPrefix)
+
+			By("creating two ArgoCD clusters")
+			targets := []Target{
+				{
+					Name:           "account5-us-west-1a-1",
+					Namespace:      namespace,
+					ApplicationSet: appSet,
+					Area:           "na",
+					Region:         "us-west-1",
+					AZ:             "us-west-1a",
+				}, {
+					Name:           "account5-us-west-1a-2",
+					Namespace:      namespace,
+					ApplicationSet: appSet,
+					Area:           "na",
+					Region:         "us-west-1",
+					AZ:             "us-west-1a",
+				},
+			}
+			clusters, err := createClusters(ctx, targets)
+			Expect(err).To(BeNil())
+			Expect(clusters).To(Not(BeNil()))
+
+			By("creating one application targeting each cluster")
+			apps, err := createApplications(ctx, targets)
+			Expect(err).To(BeNil())
+			Expect(apps).To(Not(BeNil()))
+
+			By("creating a progressive sync")
+			failedStagePS := syncv1alpha1.ProgressiveSync{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-ps", testPrefix), Namespace: namespace},
+				Spec: syncv1alpha1.ProgressiveSyncSpec{
+					SourceRef: corev1.TypedLocalObjectReference{
+						APIGroup: &appSetAPIRef,
+						Kind:     utils.AppSetKind,
+						Name:     appSet,
+					},
+					Stages: []syncv1alpha1.ProgressiveSyncStage{{
+						Name:        "stage 0",
+						MaxParallel: intstr.IntOrString{IntVal: 1},
+						MaxTargets:  intstr.IntOrString{IntVal: 1},
+						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+								"cluster": clusters[0].Name,
+							}},
+						}},
+					}, {
+						Name:        "stage 1",
+						MaxParallel: intstr.IntOrString{IntVal: 1},
+						MaxTargets:  intstr.IntOrString{IntVal: 1},
+						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+								"cluster": clusters[1].Name,
+							}},
+						}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &failedStagePS)).To(Succeed())
+
+			psKey := client.ObjectKey{
+				Namespace: namespace,
+				Name:      fmt.Sprintf("%s-ps", testPrefix),
+			}
+
+			By("progressing the first application")
+			Eventually(func() error {
+				return setAppStatusProgressing(ctx, "account5-us-west-1a-1", namespace)
+			}).Should(Succeed())
+
+			ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
+				Name:    "stage 0",
+				Phase:   syncv1alpha1.PhaseProgressing,
+				Message: "stage 0 stage in progress",
+			}))
+			ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
+
+			By("failing syncing the first application")
+			Eventually(func() error {
+				return setAppStatusFailed(ctx, "account5-us-west-1a-1", namespace)
+			}).Should(Succeed())
+
+			ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
+				Name:    "stage 0",
+				Phase:   syncv1alpha1.PhaseFailed,
+				Message: "stage 0 stage failed",
+			}))
+			ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
+
+			expected := failedStagePS.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, "stage 0 stage failed")
+			ExpectCondition(&failedStagePS, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
+		})
 	})
 
 	Describe("sync application", func() {
@@ -998,7 +984,7 @@ func setAppStatusProgressing(ctx context.Context, appName string, namespace stri
 	return k8sClient.Update(ctx, &app)
 }
 
-// setAppHealthStatuscompleted set the application health status to completed given an application name and its namespace
+// setAppStatusCompleted set the application health status to completed given an application name and its namespace
 func setAppStatusCompleted(ctx context.Context, appName string, namespace string) error {
 	app := argov1alpha1.Application{}
 	err := k8sClient.Get(ctx, client.ObjectKey{
@@ -1022,27 +1008,27 @@ func setAppStatusCompleted(ctx context.Context, appName string, namespace string
 }
 
 // setAppStatusFailed set the application health status to failed given an application name and its namespace
-// func setAppStatusFailed(ctx context.Context, appName string, namespace string) error {
-// 	app := argov1alpha1.Application{}
-// 	err := k8sClient.Get(ctx, client.ObjectKey{
-// 		Namespace: namespace,
-// 		Name:      appName,
-// 	}, &app)
+func setAppStatusFailed(ctx context.Context, appName string, namespace string) error {
+	app := argov1alpha1.Application{}
+	err := k8sClient.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      appName,
+	}, &app)
 
-// 	if err != nil {
-// 		return err
-// 	}
+	if err != nil {
+		return err
+	}
 
-// 	app.Status.Health = argov1alpha1.HealthStatus{
-// 		Status:  health.HealthStatusDegraded,
-// 		Message: "degraded",
-// 	}
-// 	app.Status.Sync = argov1alpha1.SyncStatus{
-// 		Status: argov1alpha1.SyncStatusCodeSynced,
-// 	}
+	app.Status.Health = argov1alpha1.HealthStatus{
+		Status:  health.HealthStatusDegraded,
+		Message: "degraded",
+	}
+	app.Status.Sync = argov1alpha1.SyncStatus{
+		Status: argov1alpha1.SyncStatusCodeSynced,
+	}
 
-// 	return k8sClient.Update(ctx, &app)
-// }
+	return k8sClient.Update(ctx, &app)
+}
 
 // hasAnnotation returns true if the application has an annotation with the given key and value
 func hasAnnotation(appName, namespace, key, value string) bool {
@@ -1144,10 +1130,10 @@ func TestSync(t *testing.T) {
 
 	testAppName := "foo-bar"
 
-	application, error := r.syncApp(ctx, testAppName)
+	application, err := r.syncApp(ctx, testAppName)
 
 	g := NewWithT(t)
-	g.Expect(error).To(BeNil())
+	g.Expect(err).To(BeNil())
 	g.Expect(application.Name).To(Equal(testAppName))
 }
 
@@ -1158,9 +1144,9 @@ func TestSyncErr(t *testing.T) {
 
 	testAppName := "foo-bar"
 
-	application, error := r.syncApp(ctx, testAppName)
+	application, err := r.syncApp(ctx, testAppName)
 
 	g := NewWithT(t)
 	g.Expect(application).To(BeNil())
-	g.Expect(error).ToNot(BeNil())
+	g.Expect(err).ToNot(BeNil())
 }

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -530,6 +530,18 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 					"rollout to remaining clusters")
 			}).Should(BeTrue())
 
+			// Make sure the previous stages are still completed
+			ExpectStageStatus(ctx, psKey, "one cluster as canary in eu-west-1").Should(MatchStage(syncv1alpha1.StageStatus{
+				Name:    "one cluster as canary in eu-west-1",
+				Phase:   syncv1alpha1.PhaseSucceeded,
+				Message: "one cluster as canary in eu-west-1 stage completed",
+			}))
+			ExpectStageStatus(ctx, psKey, "one cluster as canary in every other region").Should(MatchStage(syncv1alpha1.StageStatus{
+				Name:    "one cluster as canary in every other region",
+				Phase:   syncv1alpha1.PhaseSucceeded,
+				Message: "one cluster as canary in every other region stage completed",
+			}))
+
 			// Make sure the current stage is progressing
 			message = "rollout to remaining clusters stage in progress"
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -725,115 +725,115 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			ExpectCondition(&ps, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
 		})
 
-		It("should fail if unable to sync application", func() {
-			testPrefix := "failed-stages"
-			appSet := fmt.Sprintf("%s-appset", testPrefix)
-
-			By("creating two ArgoCD clusters")
-			targets := []Target{
-				{
-					Name:           "account7-eu-west-1a-1",
-					Namespace:      namespace,
-					ApplicationSet: appSet,
-					Area:           "emea",
-					Region:         "eu-west-1",
-					AZ:             "eu-west-1a",
-				}, {
-					Name:           "account7-eu-west-1a-2",
-					Namespace:      namespace,
-					ApplicationSet: appSet,
-					Area:           "emea",
-					Region:         "eu-west-1",
-					AZ:             "eu-west-1a",
-				},
-			}
-			clusters, err := createClusters(ctx, targets)
-			Expect(err).To(BeNil())
-			Expect(clusters).To(Not(BeNil()))
-
-			By("creating one application targeting each cluster")
-			apps, err := createApplications(ctx, targets)
-			Expect(err).To(BeNil())
-			Expect(apps).To(Not(BeNil()))
-
-			By("creating a progressive sync")
-			failedStagePR := syncv1alpha1.ProgressiveSync{
-				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-ps", testPrefix), Namespace: namespace},
-				Spec: syncv1alpha1.ProgressiveSyncSpec{
-					SourceRef: corev1.TypedLocalObjectReference{
-						APIGroup: &appSetAPIRef,
-						Kind:     utils.AppSetKind,
-						Name:     appSet,
-					},
-					Stages: []syncv1alpha1.ProgressiveSyncStage{{
-						Name:        "stage 0",
-						MaxParallel: intstr.IntOrString{IntVal: 1},
-						MaxTargets:  intstr.IntOrString{IntVal: 1},
-						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
-							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-								"cluster": clusters[0].Name,
-							}},
-						}},
-					}, {
-						Name:        "stage 1",
-						MaxParallel: intstr.IntOrString{IntVal: 1},
-						MaxTargets:  intstr.IntOrString{IntVal: 1},
-						Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
-							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-								"cluster": clusters[1].Name,
-							}},
-						}},
-					}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, &failedStagePR)).To(Succeed())
-
-			psKey := client.ObjectKey{
-				Namespace: namespace,
-				Name:      fmt.Sprintf("%s-ps", testPrefix),
-			}
-
-			By("progressing in first application")
-			Eventually(func() error {
-				return setAppStatusProgressing(ctx, "account7-eu-west-1a-1", namespace)
-			}).Should(Succeed())
-
-			ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
-				Name:    "stage 0",
-				Phase:   syncv1alpha1.PhaseProgressing,
-				Message: "stage 0 stage in progress",
-			}))
-			ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
-
-			By("failed syncing first application")
-			Eventually(func() error {
-				return setAppStatusFailed(ctx, "account7-eu-west-1a-1", namespace)
-			}).Should(Succeed())
-
-			ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
-				Name:    "stage 0",
-				Phase:   syncv1alpha1.PhaseFailed,
-				Message: "stage 0 stage failed",
-			}))
-			ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
-
-			createdPR := syncv1alpha1.ProgressiveSync{}
-			Eventually(func() int {
-				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &createdPR)
-				return len(createdPR.ObjectMeta.Finalizers)
-			}).Should(Equal(1))
-			Expect(createdPR.ObjectMeta.Finalizers[0]).To(Equal(syncv1alpha1.ProgressiveSyncFinalizer))
-
-			expected := failedStagePR.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, "stage 0 stage failed")
-			ExpectCondition(&failedStagePR, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
-
-			deletedPR := syncv1alpha1.ProgressiveSync{}
-			Expect(k8sClient.Delete(ctx, &failedStagePR)).To(Succeed())
-			Eventually(func() error {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &deletedPR)
-				return err
-			}).Should(HaveOccurred())
-		})
+		//It("should fail if unable to sync application", func() {
+		//	testPrefix := "failed-stages"
+		//	appSet := fmt.Sprintf("%s-appset", testPrefix)
+		//
+		//	By("creating two ArgoCD clusters")
+		//	targets := []Target{
+		//		{
+		//			Name:           "account7-eu-west-1a-1",
+		//			Namespace:      namespace,
+		//			ApplicationSet: appSet,
+		//			Area:           "emea",
+		//			Region:         "eu-west-1",
+		//			AZ:             "eu-west-1a",
+		//		}, {
+		//			Name:           "account7-eu-west-1a-2",
+		//			Namespace:      namespace,
+		//			ApplicationSet: appSet,
+		//			Area:           "emea",
+		//			Region:         "eu-west-1",
+		//			AZ:             "eu-west-1a",
+		//		},
+		//	}
+		//	clusters, err := createClusters(ctx, targets)
+		//	Expect(err).To(BeNil())
+		//	Expect(clusters).To(Not(BeNil()))
+		//
+		//	By("creating one application targeting each cluster")
+		//	apps, err := createApplications(ctx, targets)
+		//	Expect(err).To(BeNil())
+		//	Expect(apps).To(Not(BeNil()))
+		//
+		//	By("creating a progressive sync")
+		//	failedStagePR := syncv1alpha1.ProgressiveSync{
+		//		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-ps", testPrefix), Namespace: namespace},
+		//		Spec: syncv1alpha1.ProgressiveSyncSpec{
+		//			SourceRef: corev1.TypedLocalObjectReference{
+		//				APIGroup: &appSetAPIRef,
+		//				Kind:     utils.AppSetKind,
+		//				Name:     appSet,
+		//			},
+		//			Stages: []syncv1alpha1.ProgressiveSyncStage{{
+		//				Name:        "stage 0",
+		//				MaxParallel: intstr.IntOrString{IntVal: 1},
+		//				MaxTargets:  intstr.IntOrString{IntVal: 1},
+		//				Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
+		//					Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+		//						"cluster": clusters[0].Name,
+		//					}},
+		//				}},
+		//			}, {
+		//				Name:        "stage 1",
+		//				MaxParallel: intstr.IntOrString{IntVal: 1},
+		//				MaxTargets:  intstr.IntOrString{IntVal: 1},
+		//				Targets: syncv1alpha1.ProgressiveSyncTargets{Clusters: syncv1alpha1.Clusters{
+		//					Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+		//						"cluster": clusters[1].Name,
+		//					}},
+		//				}},
+		//			}},
+		//		},
+		//	}
+		//	Expect(k8sClient.Create(ctx, &failedStagePR)).To(Succeed())
+		//
+		//	psKey := client.ObjectKey{
+		//		Namespace: namespace,
+		//		Name:      fmt.Sprintf("%s-ps", testPrefix),
+		//	}
+		//
+		//	By("progressing in first application")
+		//	Eventually(func() error {
+		//		return setAppStatusProgressing(ctx, "account7-eu-west-1a-1", namespace)
+		//	}).Should(Succeed())
+		//
+		//	ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
+		//		Name:    "stage 0",
+		//		Phase:   syncv1alpha1.PhaseProgressing,
+		//		Message: "stage 0 stage in progress",
+		//	}))
+		//	ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
+		//
+		//	By("failed syncing first application")
+		//	Eventually(func() error {
+		//		return setAppStatusFailed(ctx, "account7-eu-west-1a-1", namespace)
+		//	}).Should(Succeed())
+		//
+		//	ExpectStageStatus(ctx, psKey, "stage 0").Should(MatchStage(syncv1alpha1.StageStatus{
+		//		Name:    "stage 0",
+		//		Phase:   syncv1alpha1.PhaseFailed,
+		//		Message: "stage 0 stage failed",
+		//	}))
+		//	ExpectStagesInStatus(ctx, psKey).Should(Equal(1))
+		//
+		//	createdPR := syncv1alpha1.ProgressiveSync{}
+		//	Eventually(func() int {
+		//		_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &createdPR)
+		//		return len(createdPR.ObjectMeta.Finalizers)
+		//	}).Should(Equal(1))
+		//	Expect(createdPR.ObjectMeta.Finalizers[0]).To(Equal(syncv1alpha1.ProgressiveSyncFinalizer))
+		//
+		//	expected := failedStagePR.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesFailedReason, "stage 0 stage failed")
+		//	ExpectCondition(&failedStagePR, expected.Type).Should(HaveStatus(expected.Status, expected.Reason, expected.Message))
+		//
+		//	deletedPR := syncv1alpha1.ProgressiveSync{}
+		//	Expect(k8sClient.Delete(ctx, &failedStagePR)).To(Succeed())
+		//	Eventually(func() error {
+		//		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&failedStagePR), &deletedPR)
+		//		return err
+		//	}).Should(HaveOccurred())
+		//})
 	})
 
 	Describe("sync application", func() {
@@ -1022,27 +1022,27 @@ func setAppStatusCompleted(ctx context.Context, appName string, namespace string
 }
 
 // setAppStatusFailed set the application health status to failed given an application name and its namespace
-func setAppStatusFailed(ctx context.Context, appName string, namespace string) error {
-	app := argov1alpha1.Application{}
-	err := k8sClient.Get(ctx, client.ObjectKey{
-		Namespace: namespace,
-		Name:      appName,
-	}, &app)
+// func setAppStatusFailed(ctx context.Context, appName string, namespace string) error {
+// 	app := argov1alpha1.Application{}
+// 	err := k8sClient.Get(ctx, client.ObjectKey{
+// 		Namespace: namespace,
+// 		Name:      appName,
+// 	}, &app)
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	app.Status.Health = argov1alpha1.HealthStatus{
-		Status:  health.HealthStatusDegraded,
-		Message: "degraded",
-	}
-	app.Status.Sync = argov1alpha1.SyncStatus{
-		Status: argov1alpha1.SyncStatusCodeSynced,
-	}
+// 	app.Status.Health = argov1alpha1.HealthStatus{
+// 		Status:  health.HealthStatusDegraded,
+// 		Message: "degraded",
+// 	}
+// 	app.Status.Sync = argov1alpha1.SyncStatus{
+// 		Status: argov1alpha1.SyncStatusCodeSynced,
+// 	}
 
-	return k8sClient.Update(ctx, &app)
-}
+// 	return k8sClient.Update(ctx, &app)
+// }
 
 // hasAnnotation returns true if the application has an annotation with the given key and value
 func hasAnnotation(appName, namespace, key, value string) bool {

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 10
+	timeout  = time.Second * 20
 	interval = time.Millisecond * 10
 )
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -539,7 +539,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			}))
 
 			// Make sure the ProgressiveSync is still in progress
-			progress = ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesProgressingReason, message)
 			ExpectCondition(&ps, progress.Type).Should(HaveStatus(progress.Status, progress.Reason, progress.Message))
 
 			By("progressing 50% of the third stage applications")
@@ -548,7 +547,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			}).Should(Succeed())
 
 			// Make sure the current stage is progressing
-			message = "rollout to remaining clusters stage in progress"
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{
 				Name:    "rollout to remaining clusters",
 				Phase:   syncv1alpha1.PhaseProgressing,
@@ -557,7 +555,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			ExpectStagesInStatus(ctx, psKey).Should(Equal(3))
 
 			// Make sure the ProgressiveSync status is progressing because the sync is not completed yet
-			progress = ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesProgressingReason, message)
 			ExpectCondition(&ps, progress.Type).Should(HaveStatus(progress.Status, progress.Reason, progress.Message))
 
 			By("completing 50% of the third stage applications")
@@ -583,7 +580,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			}).Should(Succeed())
 
 			// Make sure the current stage is progressing
-			message = "rollout to remaining clusters stage in progress"
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{
 				Name:    "rollout to remaining clusters",
 				Phase:   syncv1alpha1.PhaseProgressing,
@@ -592,7 +588,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			ExpectStagesInStatus(ctx, psKey).Should(Equal(3))
 
 			// Make sure the ProgressiveSync status is progressing because the sync is not completed yet
-			progress = ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesProgressingReason, message)
 			ExpectCondition(&ps, progress.Type).Should(HaveStatus(progress.Status, progress.Reason, progress.Message))
 
 			By("completing 75% of the third stage applications")
@@ -618,7 +613,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			}).Should(Succeed())
 
 			// Make sure the current stage is progressing
-			message = "rollout to remaining clusters stage in progress"
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{
 				Name:    "rollout to remaining clusters",
 				Phase:   syncv1alpha1.PhaseProgressing,
@@ -627,7 +621,6 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			ExpectStagesInStatus(ctx, psKey).Should(Equal(3))
 
 			// Make sure the ProgressiveSync status is progressing because the sync is not completed yet
-			progress = ps.NewStatusCondition(syncv1alpha1.CompletedCondition, metav1.ConditionFalse, syncv1alpha1.StagesProgressingReason, message)
 			ExpectCondition(&ps, progress.Type).Should(HaveStatus(progress.Status, progress.Reason, progress.Message))
 
 			By("completing 100% of the third stage applications")
@@ -636,6 +629,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			}).Should(Succeed())
 
 			// Make sure the current stage is completed
+			message = "rollout to remaining clusters stage completed"
 			ExpectStageStatus(ctx, psKey, "rollout to remaining clusters").Should(MatchStage(syncv1alpha1.StageStatus{
 				Name:    "rollout to remaining clusters",
 				Phase:   syncv1alpha1.PhaseSucceeded,

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 120
+	timeout  = time.Second * 300
 	interval = time.Millisecond * 10
 )
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 90
+	timeout  = time.Second * 300
 	interval = time.Millisecond * 10
 )
 

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -45,7 +45,7 @@ type Target struct {
 }
 
 func createRandomNamespace() (string, *corev1.Namespace) {
-	namespace := "progressiverollout-test-" + randStringNumber(5)
+	namespace := "progressivesync-test-" + randStringNumber(5)
 
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: namespace},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,8 +17,6 @@
 package controllers
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math/rand"
 	"path/filepath"
 	"testing"
@@ -47,8 +45,6 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var reconciler *ProgressiveSyncReconciler
-
-const namespace = "progressive-sync-tests"
 
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -86,11 +82,6 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	ns := corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: namespace},
-	}
-	Expect(k8sClient.Create(ctx, &ns)).To(Succeed())
-
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 	})
@@ -122,4 +113,14 @@ var _ = AfterSuite(func() {
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
+}
+
+var numbers = []rune("1234567890")
+
+func randStringNumber(n int) string {
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = numbers[rand.Intn(len(numbers))]
+	}
+	return string(s)
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,8 @@
 package controllers
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math/rand"
 	"path/filepath"
 	"testing"
@@ -45,6 +47,8 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var reconciler *ProgressiveSyncReconciler
+
+const namespace = "progressive-sync-tests"
 
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -82,6 +86,11 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}
+	Expect(k8sClient.Create(ctx, &ns)).To(Succeed())
+
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 	})
@@ -113,14 +122,4 @@ var _ = AfterSuite(func() {
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
-}
-
-var numbers = []rune("1234567890")
-
-func randStringNumber(n int) string {
-	s := make([]rune, n)
-	for i := range s {
-		s[i] = numbers[rand.Intn(len(numbers))]
-	}
-	return string(s)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -110,6 +110,11 @@ func IsStageFailed(apps []argov1alpha1.Application, stage syncv1alpha1.Progressi
 	// A stage is failed if any of its applications has:
 	// - its Health Status Code == Degraded
 	// - its Sync Status Code == Synced
+
+	if apps == nil {
+		return false
+	}
+
 	degradedApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusDegraded)
 	stageApps := utils.GetSyncedAppsByStage(degradedApps, stage.Name)
 	return len(stageApps) > 0

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -98,9 +98,9 @@ func IsStageComplete(apps []argov1alpha1.Application, stage syncv1alpha1.Progres
 	// An app is complete if:
 	// - its Health Status Code is Healthy
 	// - its Sync Status Code is Synced
-	completeApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusHealthy)
-	completeSyncedApps := utils.GetAppsBySyncStatusCode(completeApps, argov1alpha1.SyncStatusCodeSynced)
-	annotatedApps := utils.GetAppsBySyncAtAnnotation(completeSyncedApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
+	healthyApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusHealthy)
+	syncedApps := utils.GetAppsBySyncStatusCode(healthyApps, argov1alpha1.SyncStatusCodeSynced)
+	annotatedApps := utils.GetAppsBySyncAtAnnotation(syncedApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
 
 	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(apps), false)
 	if err != nil {
@@ -112,5 +112,5 @@ func IsStageComplete(apps []argov1alpha1.Application, stage syncv1alpha1.Progres
 		appsToCompleteStage = maxTargets
 	}
 
-	return len(annotatedApps) >= appsToCompleteStage
+	return len(annotatedApps) == appsToCompleteStage
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -111,9 +111,8 @@ func IsStageFailed(apps []argov1alpha1.Application, stage syncv1alpha1.Progressi
 	// - its Health Status Code == Degraded
 	// - its Sync Status Code == Synced
 	degradedApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusDegraded)
-	syncedApps := utils.GetAppsBySyncStatusCode(degradedApps, argov1alpha1.SyncStatusCodeSynced)
-	annotatedApps := utils.GetAppsByAnnotation(syncedApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
-	return len(annotatedApps) > 0
+	stageApps := utils.GetSyncedAppsByStage(degradedApps, stage.Name)
+	return len(stageApps) > 0
 }
 
 // IsStageInProgress returns true if at least one app is is in progress

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -39,7 +39,8 @@ func Scheduler(log logr.Logger, apps []argov1alpha1.Application, stage syncv1alp
 
 	log.Info("fetched out-of-sync apps", "apps", utils.GetAppsName(outOfSyncApps))
 
-	syncedInCurrentStage := utils.GetSyncedAppsByStage(apps, stage.Name)
+	healthyApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusHealthy)
+	syncedInCurrentStage := utils.GetSyncedAppsByStage(healthyApps, stage.Name)
 	log.Info("fetched synced-in-current-stage apps", "apps", utils.GetAppsName(syncedInCurrentStage))
 
 	progressingApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusProgressing)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -84,6 +84,7 @@ func Scheduler(log logr.Logger, apps []argov1alpha1.Application, stage syncv1alp
 	// outOfSyncApps = 4
 	// syncedInCurrentStage = 2
 	// progressingApps = 1
+	// p = 2
 	//
 	// Without the following logic we have p=2, so we would end up with a total of 4 applications synced in the stage
 	if p+len(syncedInCurrentStage) > maxTargets {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -120,6 +120,11 @@ func IsStageInProgress(apps []argov1alpha1.Application, stage syncv1alpha1.Progr
 	// An stage is in progress if:
 	// - there is at least one app with Health Status Code == Progressing
 	// - the number of apps synced so far is less than the apps to sync
+
+	if apps == nil {
+		return false
+	}
+
 	progressingApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusProgressing)
 	progressingAnnotatedApps := utils.GetAppsByAnnotation(progressingApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -100,6 +100,7 @@ func IsStageComplete(apps []argov1alpha1.Application, stage syncv1alpha1.Progres
 	// - its Sync Status Code is Synced
 	completeApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusHealthy)
 	completeSyncedApps := utils.GetAppsBySyncStatusCode(completeApps, argov1alpha1.SyncStatusCodeSynced)
+	annotatedApps := utils.GetAppsBySyncAtAnnotation(completeSyncedApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
 
 	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(apps), false)
 	if err != nil {
@@ -111,5 +112,5 @@ func IsStageComplete(apps []argov1alpha1.Application, stage syncv1alpha1.Progres
 		appsToCompleteStage = maxTargets
 	}
 
-	return len(completeSyncedApps) >= appsToCompleteStage
+	return len(annotatedApps) >= appsToCompleteStage
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -138,8 +138,7 @@ func IsStageComplete(apps []argov1alpha1.Application, stage syncv1alpha1.Progres
 	// - its Health Status Code is Healthy
 	// - its Sync Status Code is Synced
 	healthyApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusHealthy)
-	syncedApps := utils.GetAppsBySyncStatusCode(healthyApps, argov1alpha1.SyncStatusCodeSynced)
-	annotatedApps := utils.GetAppsByAnnotation(syncedApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
+	stageApps := utils.GetSyncedAppsByStage(healthyApps, stage.Name)
 
 	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(apps), false)
 	if err != nil {
@@ -151,5 +150,5 @@ func IsStageComplete(apps []argov1alpha1.Application, stage syncv1alpha1.Progres
 		appsToCompleteStage = maxTargets
 	}
 
-	return len(annotatedApps) == appsToCompleteStage
+	return len(stageApps) == appsToCompleteStage
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -76,6 +76,20 @@ func Scheduler(log logr.Logger, apps []argov1alpha1.Application, stage syncv1alp
 	if p > len(outOfSyncApps) {
 		p = len(outOfSyncApps)
 	}
+
+	// Consider the following scenario
+	//
+	// maxTargets = 3
+	// maxParallel = 3
+	// outOfSyncApps = 4
+	// syncedInCurrentStage = 2
+	// progressingApps = 1
+	//
+	// Without the following logic we have p=2, so we would end up with a total of 4 applications synced in the stage
+	if p+len(syncedInCurrentStage) > maxTargets {
+		p = maxTargets - len(syncedInCurrentStage)
+	}
+
 	for i := 0; i < p; i++ {
 		scheduledApps = append(scheduledApps, outOfSyncApps[i])
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -142,6 +142,11 @@ func IsStageComplete(apps []argov1alpha1.Application, stage syncv1alpha1.Progres
 	// An app is complete if:
 	// - its Health Status Code is Healthy
 	// - its Sync Status Code is Synced
+
+	if apps == nil {
+		return true
+	}
+
 	healthyApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusHealthy)
 	stageApps := utils.GetSyncedAppsByStage(healthyApps, stage.Name)
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -121,7 +121,7 @@ func IsStageInProgress(apps []argov1alpha1.Application, stage syncv1alpha1.Progr
 	// - there is at least one app with Health Status Code == Progressing
 	// - the number of apps synced so far is less than the apps to sync
 	progressingApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusProgressing)
-	annotatedApps := utils.GetAppsBySyncAtAnnotation(progressingApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
+	annotatedApps := utils.GetAppsByAnnotation(progressingApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
 
 	syncedApps := utils.GetSyncedAppsByStage(apps, stage.Name)
 	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(apps), false)
@@ -139,7 +139,7 @@ func IsStageComplete(apps []argov1alpha1.Application, stage syncv1alpha1.Progres
 	// - its Sync Status Code is Synced
 	healthyApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusHealthy)
 	syncedApps := utils.GetAppsBySyncStatusCode(healthyApps, argov1alpha1.SyncStatusCodeSynced)
-	annotatedApps := utils.GetAppsBySyncAtAnnotation(syncedApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
+	annotatedApps := utils.GetAppsByAnnotation(syncedApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
 
 	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(apps), false)
 	if err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -105,14 +105,15 @@ func Scheduler(log logr.Logger, apps []argov1alpha1.Application, stage syncv1alp
 	return scheduledApps
 }
 
-// IsStageFailed returns true if at least one app is failed
-func IsStageFailed(apps []argov1alpha1.Application) bool {
-	// An app is failed if:
-	// - its Health Status Code is Degraded
-	// - its Sync Status Code is Synced
+// IsStageFailed returns true if at least one app is failed in the given stage
+func IsStageFailed(apps []argov1alpha1.Application, stage syncv1alpha1.ProgressiveSyncStage) bool {
+	// A stage is failed if any of its applications has:
+	// - its Health Status Code == Degraded
+	// - its Sync Status Code == Synced
 	degradedApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusDegraded)
-	degradedSyncedApps := utils.GetAppsBySyncStatusCode(degradedApps, argov1alpha1.SyncStatusCodeSynced)
-	return len(degradedSyncedApps) > 0
+	syncedApps := utils.GetAppsBySyncStatusCode(degradedApps, argov1alpha1.SyncStatusCodeSynced)
+	annotatedApps := utils.GetAppsByAnnotation(syncedApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
+	return len(annotatedApps) > 0
 }
 
 // IsStageInProgress returns true if at least one app is is in progress

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -121,15 +121,15 @@ func IsStageInProgress(apps []argov1alpha1.Application, stage syncv1alpha1.Progr
 	// - there is at least one app with Health Status Code == Progressing
 	// - the number of apps synced so far is less than the apps to sync
 	progressingApps := utils.GetAppsByHealthStatusCode(apps, health.HealthStatusProgressing)
-	annotatedApps := utils.GetAppsByAnnotation(progressingApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
+	progressingAnnotatedApps := utils.GetAppsByAnnotation(progressingApps, utils.ProgressiveSyncSyncedAtStageKey, stage.Name)
 
-	syncedApps := utils.GetSyncedAppsByStage(apps, stage.Name)
+	stageApps := utils.GetSyncedAppsByStage(apps, stage.Name)
 	maxTargets, err := intstr.GetScaledValueFromIntOrPercent(&stage.MaxTargets, len(apps), false)
 	if err != nil {
 		return false
 	}
 
-	return len(annotatedApps) > 0 || len(syncedApps) < maxTargets
+	return len(progressingAnnotatedApps) > 0 || len(stageApps) < maxTargets
 }
 
 // IsStageComplete returns true if all applications are Synced and Healthy

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -94,6 +94,13 @@ func Scheduler(log logr.Logger, apps []argov1alpha1.Application, stage syncv1alp
 	for i := 0; i < p; i++ {
 		scheduledApps = append(scheduledApps, outOfSyncApps[i])
 	}
+
+	// To recover from a case where something triggers an Application sync, the scheulder also return
+	// all the progressing apps but still out of sync, so we can add the annotation and take back control of the app
+
+	progressingOutOfSyncApps := utils.GetAppsBySyncStatusCode(progressingApps, argov1alpha1.SyncStatusCodeOutOfSync)
+	scheduledApps = append(scheduledApps, progressingOutOfSyncApps...)
+
 	return scheduledApps
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -855,6 +855,7 @@ func TestIsStageFailed(t *testing.T) {
 	testCases := []struct {
 		name     string
 		apps     []argov1alpha1.Application
+		stage    syncv1alpha1.ProgressiveSyncStage
 		expected bool
 	}{
 		{
@@ -934,6 +935,9 @@ func TestIsStageFailed(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "app-six",
 						Namespace: SchedulerTestNamespace,
+						Annotations: map[string]string{
+							utils.ProgressiveSyncSyncedAtStageKey: StageName,
+						},
 					},
 					Status: argov1alpha1.ApplicationStatus{
 						Health: argov1alpha1.HealthStatus{
@@ -944,6 +948,12 @@ func TestIsStageFailed(t *testing.T) {
 						},
 					},
 				},
+			},
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
 			},
 			expected: true,
 		},
@@ -1021,13 +1031,19 @@ func TestIsStageFailed(t *testing.T) {
 					},
 				},
 			},
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
 			expected: false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := IsStageFailed(testCase.apps)
+			got := IsStageFailed(testCase.apps, testCase.stage)
 			g := NewWithT(t)
 			g.Expect(got).To(Equal(testCase.expected))
 		})

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -895,312 +895,312 @@ func TestIsStageFailed(t *testing.T) {
 	}
 }
 
-func TestIsStageInProgress(t *testing.T) {
-	testCases := []struct {
-		name     string
-		apps     []argov1alpha1.Application
-		expected bool
-	}{
-		{
-			name: "stage in progress",
-			apps: []argov1alpha1.Application{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-one",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusUnknown,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-two",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusHealthy,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-three",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusDegraded,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-four",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusMissing,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-five",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusSuspended,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-six",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusProgressing,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "stage not in progress",
-			apps: []argov1alpha1.Application{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-one",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusUnknown,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-two",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusHealthy,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-three",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusDegraded,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-four",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusMissing,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-five",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusSuspended,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-			},
-			expected: false,
-		},
-	}
+// func TestIsStageInProgress(t *testing.T) {
+// 	testCases := []struct {
+// 		name     string
+// 		apps     []argov1alpha1.Application
+// 		expected bool
+// 	}{
+// 		{
+// 			name: "stage in progress",
+// 			apps: []argov1alpha1.Application{
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-one",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusUnknown,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-two",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusHealthy,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-three",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusDegraded,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-four",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusMissing,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-five",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusSuspended,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-six",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusProgressing,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			expected: true,
+// 		},
+// 		{
+// 			name: "stage not in progress",
+// 			apps: []argov1alpha1.Application{
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-one",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusUnknown,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-two",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusHealthy,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-three",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusDegraded,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-four",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusMissing,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-five",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusSuspended,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			expected: false,
+// 		},
+// 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			got := IsStageInProgress(testCase.apps)
-			g := NewWithT(t)
-			g.Expect(got).To(Equal(testCase.expected))
-		})
-	}
-}
+// 	for _, testCase := range testCases {
+// 		t.Run(testCase.name, func(t *testing.T) {
+// 			got := IsStageInProgress(testCase.apps)
+// 			g := NewWithT(t)
+// 			g.Expect(got).To(Equal(testCase.expected))
+// 		})
+// 	}
+// }
 
-func TestIsStageComplete(t *testing.T) {
-	testCases := []struct {
-		name     string
-		apps     []argov1alpha1.Application
-		expected bool
-	}{
-		{
-			name: "stage is complete",
-			apps: []argov1alpha1.Application{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-one",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusHealthy,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-two",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusHealthy,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-three",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusHealthy,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "stage is not complete",
-			apps: []argov1alpha1.Application{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-one",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusHealthy,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeOutOfSync,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-two",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusDegraded,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-three",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusMissing,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeUnknown,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-four",
-						Namespace: SchedulerTestNamespace,
-					},
-					Status: argov1alpha1.ApplicationStatus{
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusHealthy,
-						},
-						Sync: argov1alpha1.SyncStatus{
-							Status: argov1alpha1.SyncStatusCodeSynced,
-						},
-					},
-				},
-			},
-			expected: false,
-		},
-	}
+// func TestIsStageComplete(t *testing.T) {
+// 	testCases := []struct {
+// 		name     string
+// 		apps     []argov1alpha1.Application
+// 		expected bool
+// 	}{
+// 		{
+// 			name: "stage is complete",
+// 			apps: []argov1alpha1.Application{
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-one",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusHealthy,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-two",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusHealthy,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-three",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusHealthy,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			expected: true,
+// 		},
+// 		{
+// 			name: "stage is not complete",
+// 			apps: []argov1alpha1.Application{
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-one",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusHealthy,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-two",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusDegraded,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-three",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusMissing,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeUnknown,
+// 						},
+// 					},
+// 				},
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "app-four",
+// 						Namespace: SchedulerTestNamespace,
+// 					},
+// 					Status: argov1alpha1.ApplicationStatus{
+// 						Health: argov1alpha1.HealthStatus{
+// 							Status: health.HealthStatusHealthy,
+// 						},
+// 						Sync: argov1alpha1.SyncStatus{
+// 							Status: argov1alpha1.SyncStatusCodeSynced,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			expected: false,
+// 		},
+// 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			got := IsStageComplete(testCase.apps)
-			g := NewWithT(t)
-			g.Expect(got).To(Equal(testCase.expected))
-		})
-	}
-}
+// 	for _, testCase := range testCases {
+// 		t.Run(testCase.name, func(t *testing.T) {
+// 			got := IsStageComplete(testCase.apps)
+// 			g := NewWithT(t)
+// 			g.Expect(got).To(Equal(testCase.expected))
+// 		})
+// 	}
+// }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -700,7 +700,7 @@ func TestScheduler(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "Applications: outOfSync 4, syncedInCurrentStage 2, progressing 1, syncedInPreviousStage 2 | Stage: maxTargets 3, maxParallel 3 | Expected: scheduled 1",
+			name: "Applications: outOfSync 4, syncedInCurrentStage 2, progressing 1, syncedInPreviousStage 2 | Stage: maxTargets 3, maxParallel 3 | Expected: scheduled 2",
 			apps: []argov1alpha1.Application{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -819,6 +819,20 @@ func TestScheduler(t *testing.T) {
 					Status: argov1alpha1.ApplicationStatus{
 						Sync: argov1alpha1.SyncStatus{
 							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusProgressing,
 						},
 					},
 				},

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1251,7 +1251,7 @@ func TestIsStageInProgress(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "stage not in progress when apps nil",
+			name: "stage not in progress when apps is nil",
 			apps: nil,
 			stage: syncv1alpha1.ProgressiveSyncStage{
 				Name:        StageName,
@@ -1272,129 +1272,159 @@ func TestIsStageInProgress(t *testing.T) {
 	}
 }
 
-// func TestIsStageComplete(t *testing.T) {
-// 	testCases := []struct {
-// 		name     string
-// 		apps     []argov1alpha1.Application
-// 		expected bool
-// 	}{
-// 		{
-// 			name: "stage is complete",
-// 			apps: []argov1alpha1.Application{
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-one",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusHealthy,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-two",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusHealthy,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-three",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusHealthy,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 			},
-// 			expected: true,
-// 		},
-// 		{
-// 			name: "stage is not complete",
-// 			apps: []argov1alpha1.Application{
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-one",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusHealthy,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeOutOfSync,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-two",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusDegraded,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-three",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusMissing,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeUnknown,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-four",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusHealthy,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 			},
-// 			expected: false,
-// 		},
-// 	}
+func TestIsStageComplete(t *testing.T) {
+	testCases := []struct {
+		name     string
+		apps     []argov1alpha1.Application
+		stage    syncv1alpha1.ProgressiveSyncStage
+		expected bool
+	}{
+		{
+			name: "stage is complete",
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: SchedulerTestNamespace,
+						Annotations: map[string]string{
+							utils.ProgressiveSyncSyncedAtStageKey: StageName,
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: SchedulerTestNamespace,
+						Annotations: map[string]string{
+							utils.ProgressiveSyncSyncedAtStageKey: StageName,
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+			},
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("2"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
+			expected: true,
+		},
+		{
+			name: "stage is not complete",
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusDegraded,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusMissing,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeUnknown,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+			},
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
+			expected: false,
+		},
+		{
+			name: "stage is completed when apps is nil",
+			apps: nil,
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
+			expected: true,
+		},
+	}
 
-// 	for _, testCase := range testCases {
-// 		t.Run(testCase.name, func(t *testing.T) {
-// 			got := IsStageComplete(testCase.apps)
-// 			g := NewWithT(t)
-// 			g.Expect(got).To(Equal(testCase.expected))
-// 		})
-// 	}
-// }
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := IsStageComplete(testCase.apps, testCase.stage)
+			g := NewWithT(t)
+			g.Expect(got).To(Equal(testCase.expected))
+		})
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1039,6 +1039,17 @@ func TestIsStageFailed(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "stage not failed when apps is nil",
+			apps: nil,
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
+			expected: false,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -619,7 +619,6 @@ func TestScheduler(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "Applications: outOfSync 2, syncedInCurrentStage 0, progressing 0, syncedInPreviousStage 1 | Stage: maxTargets 2, maxParallel 2 | Expected: scheduled 2",
 			apps: []argov1alpha1.Application{
@@ -689,7 +688,6 @@ func TestScheduler(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "Applications: outOfSync 0, syncedInCurrentStage 0, progressing 0, | Stage: maxTargets 3, maxParallel 3 | Expected: scheduled 0",
 			apps: nil,
@@ -700,6 +698,131 @@ func TestScheduler(t *testing.T) {
 				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
 			},
 			expected: nil,
+		},
+		{
+			name: "Applications: outOfSync 4, syncedInCurrentStage 2, progressing 1, syncedInPreviousStage 2 | Stage: maxTargets 3, maxParallel 3 | Expected: scheduled 1",
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "app-one",
+						Namespace:   SchedulerTestNamespace,
+						Annotations: map[string]string{utils.ProgressiveSyncSyncedAtStageKey: StageName},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "app-two",
+						Namespace:   SchedulerTestNamespace,
+						Annotations: map[string]string{utils.ProgressiveSyncSyncedAtStageKey: StageName},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusProgressing,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-six",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "app-seven",
+						Namespace:   SchedulerTestNamespace,
+						Annotations: map[string]string{utils.ProgressiveSyncSyncedAtStageKey: "previous-stage"},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "app-eight",
+						Namespace:   SchedulerTestNamespace,
+						Annotations: map[string]string{utils.ProgressiveSyncSyncedAtStageKey: "previous-stage"},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+			},
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("3"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
+			expected: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"github.com/go-logr/logr"
 	"testing"
 
 	syncv1alpha1 "github.com/Skyscanner/applicationset-progressive-sync/api/v1alpha1"
@@ -703,9 +704,10 @@ func TestScheduler(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		log := logr.Discard()
 		t.Run(testCase.name, func(t *testing.T) {
 			utils.SortAppsByName(testCase.apps)
-			got := Scheduler(testCase.apps, testCase.stage)
+			got := Scheduler(log, testCase.apps, testCase.stage)
 			g := NewWithT(t)
 			g.Expect(got).To(Equal(testCase.expected))
 		})

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1050,188 +1050,227 @@ func TestIsStageFailed(t *testing.T) {
 	}
 }
 
-// func TestIsStageInProgress(t *testing.T) {
-// 	testCases := []struct {
-// 		name     string
-// 		apps     []argov1alpha1.Application
-// 		expected bool
-// 	}{
-// 		{
-// 			name: "stage in progress",
-// 			apps: []argov1alpha1.Application{
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-one",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusUnknown,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-two",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusHealthy,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-three",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusDegraded,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-four",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusMissing,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-five",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusSuspended,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-six",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusProgressing,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 			},
-// 			expected: true,
-// 		},
-// 		{
-// 			name: "stage not in progress",
-// 			apps: []argov1alpha1.Application{
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-one",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusUnknown,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-two",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusHealthy,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-three",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusDegraded,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-four",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusMissing,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 				{
-// 					ObjectMeta: metav1.ObjectMeta{
-// 						Name:      "app-five",
-// 						Namespace: SchedulerTestNamespace,
-// 					},
-// 					Status: argov1alpha1.ApplicationStatus{
-// 						Health: argov1alpha1.HealthStatus{
-// 							Status: health.HealthStatusSuspended,
-// 						},
-// 						Sync: argov1alpha1.SyncStatus{
-// 							Status: argov1alpha1.SyncStatusCodeSynced,
-// 						},
-// 					},
-// 				},
-// 			},
-// 			expected: false,
-// 		},
-// 	}
+func TestIsStageInProgress(t *testing.T) {
+	testCases := []struct {
+		name     string
+		apps     []argov1alpha1.Application
+		stage    syncv1alpha1.ProgressiveSyncStage
+		expected bool
+	}{
+		{
+			name: "stage in progress",
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusUnknown,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusDegraded,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusMissing,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusSuspended,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-six",
+						Namespace: SchedulerTestNamespace,
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusProgressing,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+			},
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
+			expected: true,
+		},
+		{
+			name: "stage not in progress",
+			apps: []argov1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-one",
+						Namespace: SchedulerTestNamespace,
+						Annotations: map[string]string{
+							utils.ProgressiveSyncSyncedAtStageKey: StageName,
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusUnknown,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-two",
+						Namespace: SchedulerTestNamespace,
+						Annotations: map[string]string{
+							utils.ProgressiveSyncSyncedAtStageKey: StageName,
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-three",
+						Namespace: SchedulerTestNamespace,
+						Annotations: map[string]string{
+							utils.ProgressiveSyncSyncedAtStageKey: StageName,
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusDegraded,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-four",
+						Namespace: SchedulerTestNamespace,
+						Annotations: map[string]string{
+							utils.ProgressiveSyncSyncedAtStageKey: StageName,
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusMissing,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-five",
+						Namespace: SchedulerTestNamespace,
+						Annotations: map[string]string{
+							utils.ProgressiveSyncSyncedAtStageKey: StageName,
+						},
+					},
+					Status: argov1alpha1.ApplicationStatus{
+						Health: argov1alpha1.HealthStatus{
+							Status: health.HealthStatusSuspended,
+						},
+						Sync: argov1alpha1.SyncStatus{
+							Status: argov1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+			},
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
+			expected: false,
+		},
+		{
+			name: "stage not in progress when apps nil",
+			apps: nil,
+			stage: syncv1alpha1.ProgressiveSyncStage{
+				Name:        StageName,
+				MaxParallel: intstr.Parse("2"),
+				MaxTargets:  intstr.Parse("3"),
+				Targets:     syncv1alpha1.ProgressiveSyncTargets{},
+			},
+			expected: false,
+		},
+	}
 
-// 	for _, testCase := range testCases {
-// 		t.Run(testCase.name, func(t *testing.T) {
-// 			got := IsStageInProgress(testCase.apps)
-// 			g := NewWithT(t)
-// 			g.Expect(got).To(Equal(testCase.expected))
-// 		})
-// 	}
-// }
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := IsStageInProgress(testCase.apps, testCase.stage)
+			g := NewWithT(t)
+			g.Expect(got).To(Equal(testCase.expected))
+		})
+	}
+}
 
 // func TestIsStageComplete(t *testing.T) {
 // 	testCases := []struct {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -39,6 +39,22 @@ func GetAppsBySyncStatusCode(apps []argov1alpha1.Application, code argov1alpha1.
 	return result
 }
 
+// GetAppsBySyncAtAnnotation returns the Applications having the specified annotation
+func GetAppsBySyncAtAnnotation(apps []argov1alpha1.Application, annotation string, stageName string) []argov1alpha1.Application {
+	var result []argov1alpha1.Application
+
+	for _, app := range apps {
+
+		value, ok := app.Annotations[annotation]
+
+		if ok && value == stageName {
+			result = append(result, app)
+		}
+	}
+
+	return result
+}
+
 // GetAppsByHealthStatusCode returns the Applications matching the specified health status code
 func GetAppsByHealthStatusCode(apps []argov1alpha1.Application, code health.HealthStatusCode) []argov1alpha1.Application {
 	var result []argov1alpha1.Application

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -74,7 +74,7 @@ func GetSyncedAppsByStage(apps []argov1alpha1.Application, name string) []argov1
 
 	for _, app := range apps {
 		val, ok := app.Annotations[ProgressiveSyncSyncedAtStageKey]
-		if ok && val == name && app.Status.Sync.Status == argov1alpha1.SyncStatusCodeSynced && app.Status.Health.Status == health.HealthStatusHealthy {
+		if ok && val == name && app.Status.Sync.Status == argov1alpha1.SyncStatusCodeSynced {
 			result = append(result, app)
 		}
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -82,7 +82,7 @@ func GetSyncedAppsByStage(apps []argov1alpha1.Application, name string) []argov1
 	return result
 }
 
-// GetClustersName returns a string containing a comma-separated list of names of the given apps
+// GetAppsName returns a string containing a comma-separated list of names of the given apps
 func GetAppsName(apps []argov1alpha1.Application) string {
 	var names []string
 	for _, a := range apps {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -39,8 +39,8 @@ func GetAppsBySyncStatusCode(apps []argov1alpha1.Application, code argov1alpha1.
 	return result
 }
 
-// GetAppsBySyncAtAnnotation returns the Applications having the specified annotation
-func GetAppsBySyncAtAnnotation(apps []argov1alpha1.Application, annotation string, stageName string) []argov1alpha1.Application {
+// GetAppsByAnnotation returns the Applications having the specified annotation
+func GetAppsByAnnotation(apps []argov1alpha1.Application, annotation string, stageName string) []argov1alpha1.Application {
 	var result []argov1alpha1.Application
 
 	for _, app := range apps {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	argov1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,7 +101,7 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 		expected []argov1alpha1.Application
 	}{
 		{
-			name: "Correct annotation, stage, sync status, health status",
+			name: "Correct annotation, stage, sync status",
 			apps: []argov1alpha1.Application{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "appA",
@@ -113,9 +112,6 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 				Status: argov1alpha1.ApplicationStatus{
 					Sync: argov1alpha1.SyncStatus{
 						Status: argov1alpha1.SyncStatusCodeSynced},
-					Health: argov1alpha1.HealthStatus{
-						Status: health.HealthStatusHealthy,
-					},
 				},
 			}},
 			stage: stage,
@@ -129,14 +125,11 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 				Status: argov1alpha1.ApplicationStatus{
 					Sync: argov1alpha1.SyncStatus{
 						Status: argov1alpha1.SyncStatusCodeSynced},
-					Health: argov1alpha1.HealthStatus{
-						Status: health.HealthStatusHealthy,
-					},
 				},
 			}},
 		},
 		{
-			name: "Correct annotation, sync status, health status. Incorrect annotation value",
+			name: "Correct annotation, sync status but incorrect annotation value",
 			apps: []argov1alpha1.Application{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "appA",
@@ -147,36 +140,13 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 				Status: argov1alpha1.ApplicationStatus{
 					Sync: argov1alpha1.SyncStatus{
 						Status: argov1alpha1.SyncStatusCodeSynced},
-					Health: argov1alpha1.HealthStatus{
-						Status: health.HealthStatusHealthy,
-					},
 				}},
 			},
 			stage:    stage,
 			expected: nil,
 		},
 		{
-			name: "Correct annotation, value, sync status. Incorrect health status",
-			apps: []argov1alpha1.Application{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "appA",
-					Namespace: namespace,
-					Annotations: map[string]string{
-						ProgressiveSyncSyncedAtStageKey: stage,
-					}},
-				Status: argov1alpha1.ApplicationStatus{
-					Sync: argov1alpha1.SyncStatus{
-						Status: argov1alpha1.SyncStatusCodeSynced},
-					Health: argov1alpha1.HealthStatus{
-						Status: health.HealthStatusProgressing,
-					},
-				}},
-			},
-			stage:    stage,
-			expected: nil,
-		},
-		{
-			name: "Correct annotation, value and health status. Incorrect sync status",
+			name: "Correct annotation, value but incorrect sync status",
 			apps: []argov1alpha1.Application{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "appA",
@@ -187,10 +157,7 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 				Status: argov1alpha1.ApplicationStatus{
 					Sync: argov1alpha1.SyncStatus{
 						Status: argov1alpha1.SyncStatusCodeOutOfSync},
-					Health: argov1alpha1.HealthStatus{
-						Status: health.HealthStatusHealthy,
-					}},
-			},
+				}},
 			},
 			stage:    stage,
 			expected: nil,
@@ -205,16 +172,13 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 				Status: argov1alpha1.ApplicationStatus{
 					Sync: argov1alpha1.SyncStatus{
 						Status: argov1alpha1.SyncStatusCodeSynced},
-					Health: argov1alpha1.HealthStatus{
-						Status: health.HealthStatusHealthy,
-					}},
-			},
+				}},
 			},
 			stage:    stage,
 			expected: nil,
 		},
 		{
-			name: "2 Applications: 1 with correct annotation, stage, sync status, health status. 1 with incorrect data",
+			name: "2 Applications: 1 with correct annotation, stage, sync status and 1 with incorrect data",
 			apps: []argov1alpha1.Application{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "appA",
@@ -225,9 +189,6 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 				Status: argov1alpha1.ApplicationStatus{
 					Sync: argov1alpha1.SyncStatus{
 						Status: argov1alpha1.SyncStatusCodeSynced},
-					Health: argov1alpha1.HealthStatus{
-						Status: health.HealthStatusHealthy,
-					},
 				},
 			},
 				{
@@ -238,9 +199,6 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 					Status: argov1alpha1.ApplicationStatus{
 						Sync: argov1alpha1.SyncStatus{
 							Status: argov1alpha1.SyncStatusCodeOutOfSync,
-						},
-						Health: argov1alpha1.HealthStatus{
-							Status: health.HealthStatusProgressing,
 						},
 					},
 				}},
@@ -255,9 +213,6 @@ func TestGetSyncedAppsByStage(t *testing.T) {
 				Status: argov1alpha1.ApplicationStatus{
 					Sync: argov1alpha1.SyncStatus{
 						Status: argov1alpha1.SyncStatusCodeSynced},
-					Health: argov1alpha1.HealthStatus{
-						Status: health.HealthStatusHealthy,
-					},
 				},
 			}},
 		},


### PR DESCRIPTION
Fix #103 

- As discussed in #103 , the https://github.com/Skyscanner/applicationset-progressive-sync/blob/main/controllers/progressivesync_controller_test.go#L268 test has a very naive ProgressiveSync object: two stages with a selector that returns only one cluster, and targeting a single cluster at the time.

We should change this test to better reflect a real case scenario. We've internally used as default the ProgressiveSync reported in #103 so this PR change the test to use that ProgressiveSync.

In addition, I changed a couple of helpers function to be more generic for when we want to add more tests with different combination of clusters.

**TODO**

- [x] ~Fix MaxTargets to return a percentange of the remaining Out Of Sync apps instead of all the apps~ we will address this in https://github.com/Skyscanner/applicationset-progressive-sync/issues/112 because it's a quite big change
- [x] Decomment scheduler tests
- [x] Decomment removeAnnotation

This is a fork of #104 on commit cab8fff024c43a064ae7aab359f14caa14ff0f7a