### PR TITLE
Bumps build-push-action version in release-artifacts.yaml

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           push: true
           tags: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Aligns the version to be the same as in https://github.com/Skyscanner/applicationset-progressive-sync/blob/main/.github/workflows/test-build.yaml#L62