### PR TITLE
Multi namespace

### DIFF
--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -82,18 +82,18 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 	format.TruncatedDiff = false
 
 	var (
-		namespace string
-		ns        *corev1.Namespace
+		ctrlNamespace string
+		ns            *corev1.Namespace
 	)
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
 
-		namespace, ns = createRandomNamespace()
+		ctrlNamespace, ns = createRandomNamespace()
 
 		k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 			Scheme:   scheme.Scheme,
-			NewCache: cache.MultiNamespacedCacheBuilder([]string{namespace, argoNamespace}),
+			NewCache: cache.MultiNamespacedCacheBuilder([]string{ctrlNamespace, argoNamespace}),
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -154,7 +154,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 		It("should filter out events for non-owned applications", func() {
 			By("creating a non-owned application")
-			ownerPR := createOwnerPR(namespace, "owner-pr")
+			ownerPR := createOwnerPR(ctrlNamespace, "owner-pr")
 			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
 			nonOwnedApp := argov1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
@@ -181,7 +181,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 	Describe("requestsForSecretChange function", func() {
 
 		It("should forward an event for a matching argocd secret", func() {
-			ownerPR := createOwnerPR(namespace, "secret-owner-pr")
+			ownerPR := createOwnerPR(ctrlNamespace, "secret-owner-pr")
 			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
 			serverURL := "https://kubernetes.default.svc"
 
@@ -218,7 +218,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 		})
 
 		It("should not forward an event for a generic secret", func() {
-			ownerPR := createOwnerPR(namespace, "generic-owner-pr")
+			ownerPR := createOwnerPR(ctrlNamespace, "generic-owner-pr")
 			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
 			By("creating a generic secret")
 			generic := corev1.Secret{
@@ -233,7 +233,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 		})
 
 		It("should not forward an event for an argocd secret not matching any application", func() {
-			ownerPR := createOwnerPR(namespace, "owner-pr")
+			ownerPR := createOwnerPR(ctrlNamespace, "owner-pr")
 			Expect(k8sClient.Create(ctx, ownerPR)).To(Succeed())
 
 			By("creating an application")
@@ -353,7 +353,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			ps := syncv1alpha1.ProgressiveSync{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("%s-ps", testPrefix),
-					Namespace: namespace,
+					Namespace: ctrlNamespace,
 				},
 				Spec: syncv1alpha1.ProgressiveSyncSpec{
 					SourceRef: corev1.TypedLocalObjectReference{
@@ -407,7 +407,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Expect(createdPS.ObjectMeta.Finalizers[0]).To(Equal(syncv1alpha1.ProgressiveSyncFinalizer))
 
 			psKey := client.ObjectKey{
-				Namespace: namespace,
+				Namespace: ctrlNamespace,
 				Name:      fmt.Sprintf("%s-ps", testPrefix),
 			}
 
@@ -760,7 +760,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 			By("creating a progressive sync")
 			failedStagePS := syncv1alpha1.ProgressiveSync{
-				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-ps", testPrefix), Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-ps", testPrefix), Namespace: ctrlNamespace},
 				Spec: syncv1alpha1.ProgressiveSyncSpec{
 					SourceRef: corev1.TypedLocalObjectReference{
 						APIGroup: &appSetAPIRef,
@@ -791,7 +791,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Expect(k8sClient.Create(ctx, &failedStagePS)).To(Succeed())
 
 			psKey := client.ObjectKey{
-				Namespace: namespace,
+				Namespace: ctrlNamespace,
 				Name:      fmt.Sprintf("%s-ps", testPrefix),
 			}
 
@@ -883,7 +883,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			syncedStagePS := syncv1alpha1.ProgressiveSync{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("%s-ps", testPrefix),
-					Namespace: namespace,
+					Namespace: ctrlNamespace,
 				},
 				Spec: syncv1alpha1.ProgressiveSyncSpec{
 					SourceRef: corev1.TypedLocalObjectReference{
@@ -929,7 +929,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 			Expect(k8sClient.Create(ctx, &syncedStagePS)).To(Succeed())
 
 			psKey := client.ObjectKey{
-				Namespace: namespace,
+				Namespace: ctrlNamespace,
 				Name:      fmt.Sprintf("%s-ps", testPrefix),
 			}
 			ExpectStageStatus(ctx, psKey, "one cluster as canary in eu-west-1").Should(MatchStage(syncv1alpha1.StageStatus{
@@ -993,7 +993,7 @@ var _ = Describe("ProgressiveRollout Controller", func() {
 
 			By("creating a progressive sync")
 			singleStagePR := syncv1alpha1.ProgressiveSync{
-				ObjectMeta: metav1.ObjectMeta{Name: "single-stage-pr", Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "single-stage-pr", Namespace: ctrlNamespace},
 				Spec: syncv1alpha1.ProgressiveSyncSpec{
 					SourceRef: corev1.TypedLocalObjectReference{
 						APIGroup: &appSetAPIRef,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,9 @@
 package controllers
 
 import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math/rand"
 	"path/filepath"
 	"testing"
@@ -38,6 +41,8 @@ import (
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+const argoNamespace = "argocd"
 
 var cfg *rest.Config
 var k8sClient client.Client
@@ -78,6 +83,11 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: argoNamespace},
+	}
+	Expect(k8sClient.Create(context.Background(), &ns)).To(Succeed())
 
 	close(done)
 }, 60)

--- a/main.go
+++ b/main.go
@@ -18,9 +18,9 @@ package main
 
 import (
 	"flag"
-	"os"
-
 	"github.com/Skyscanner/applicationset-progressive-sync/internal/utils"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -48,10 +48,11 @@ func init() {
 }
 
 func main() {
-	var metricsAddr, namespace string
+	var metricsAddr, namespace, argoNamespace string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&namespace, "namespace", "argocd", "The controller namespace")
+	flag.StringVar(&argoNamespace, "argo-namespace", "argocd", "The namespace where ArgoCD and ApplicationSet controller are deployed to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -61,10 +62,15 @@ func main() {
 	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	namespaces := []string{namespace}
+	if namespace != argoNamespace {
+		namespaces = append(namespaces, argoNamespace)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
-		Namespace:          namespace,
 		MetricsBindAddress: metricsAddr,
+		NewCache:           cache.MultiNamespacedCacheBuilder(namespaces),
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "b84175a0.argoproj.skyscanner.net",

--- a/main.go
+++ b/main.go
@@ -48,11 +48,11 @@ func init() {
 }
 
 func main() {
-	var metricsAddr, namespace, argoNamespace string
+	var metricsAddr, ctrlNamespace, argoNamespace string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&namespace, "namespace", "argocd", "The controller namespace")
-	flag.StringVar(&argoNamespace, "argo-namespace", "argocd", "The namespace where ArgoCD and ApplicationSet controller are deployed to.")
+	flag.StringVar(&ctrlNamespace, "ctrl-namespace", "argocd", "The controller namespace")
+	flag.StringVar(&argoNamespace, "argo-namespace", "argocd", "The namespace where ArgoCD and the ApplicationSet controller are deployed to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -62,8 +62,8 @@ func main() {
 	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	namespaces := []string{namespace}
-	if namespace != argoNamespace {
+	namespaces := []string{ctrlNamespace}
+	if ctrlNamespace != argoNamespace {
 		namespaces = append(namespaces, argoNamespace)
 	}
 


### PR DESCRIPTION
Fix https://github.com/Skyscanner/applicationset-progressive-sync/issues/131

In the tests, I moved the Argo objects inside the `argocd` namespace and left the ProgressiveSync objects inside the random generated namespace. In this way we can test the controller watching multiple namespaces.