### PR TITLE
Allow to specify controller and argocd namespaces

### DIFF
--- a/charts/applicationset-progressive-sync/Chart.yaml
+++ b/charts/applicationset-progressive-sync/Chart.yaml
@@ -16,7 +16,7 @@ version: 0.3.0-prealpha
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.0-prealpha"
+appVersion: "v0.4.0-prealpha"
 
 keywords:
   - argoproj

--- a/charts/applicationset-progressive-sync/Chart.yaml
+++ b/charts/applicationset-progressive-sync/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2-prealpha
+version: 0.3.0-prealpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/applicationset-progressive-sync/README.md
+++ b/charts/applicationset-progressive-sync/README.md
@@ -1,6 +1,6 @@
 # applicationset-progressive-sync
 
-![Version: 0.3.0-prealpha](https://img.shields.io/badge/Version-0.3.0--prealpha-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0-prealpha](https://img.shields.io/badge/AppVersion-v0.2.0--prealpha-informational?style=flat-square)
+![Version: 0.3.0-prealpha](https://img.shields.io/badge/Version-0.3.0--prealpha-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0-prealpha](https://img.shields.io/badge/AppVersion-v0.4.0--prealpha-informational?style=flat-square)
 
 A Helm chart to install the applicationset-progressive-sync controller.
 
@@ -37,7 +37,7 @@ Users of Helm v2 should use `--set installCRDs=true` to install the CRDs.
 | configSecret.name | string | `""` | If this value is not provided, a secret will be generated |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"maruina/applicationset-progressive-sync"` |  |
+| image.repository | string | `"ghcr.io/skyscanner/applicationset-progressive-sync"` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `false` |  |

--- a/charts/applicationset-progressive-sync/README.md
+++ b/charts/applicationset-progressive-sync/README.md
@@ -29,7 +29,6 @@ Users of Helm v2 should use `--set installCRDs=true` to install the CRDs.
 | args.argoNamespace | string | `"argocd"` | The namespace where ArgoCD and the ApplicationSet controller are deployed to. |
 | args.enableLeaderElection | bool | `false` | Enable leader election for controller manager. |
 | args.metricsAddr | string | `":8080"` | The address the metric endpoint binds to. |
-| args.namespace | string | `"argocd"` | The controller namespace. |
 | config | object | `{"argoCDAuthToken":"example-token","argoCDInsecure":"true","argoCDServerAddr":"argocd-server"}` | Config options |
 | config.argoCDAuthToken | string | `"example-token"` | ArgoCD token |
 | config.argoCDInsecure | string | `"true"` | Allow insecure connection with ArgoCD server |

--- a/charts/applicationset-progressive-sync/README.md
+++ b/charts/applicationset-progressive-sync/README.md
@@ -1,6 +1,6 @@
 # applicationset-progressive-sync
 
-![Version: 0.1.5-prealpha](https://img.shields.io/badge/Version-0.1.5--prealpha-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0-prealpha](https://img.shields.io/badge/AppVersion-v0.2.0--prealpha-informational?style=flat-square)
+![Version: 0.3.0-prealpha](https://img.shields.io/badge/Version-0.3.0--prealpha-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0-prealpha](https://img.shields.io/badge/AppVersion-v0.2.0--prealpha-informational?style=flat-square)
 
 A Helm chart to install the applicationset-progressive-sync controller.
 
@@ -26,8 +26,10 @@ Users of Helm v2 should use `--set installCRDs=true` to install the CRDs.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| args.enableLeaderElection | bool | `false` |  |
-| args.metricsAddr | string | `":8080"` |  |
+| args.argoNamespace | string | `"argocd"` | The namespace where ArgoCD and the ApplicationSet controller are deployed to. |
+| args.enableLeaderElection | bool | `false` | Enable leader election for controller manager. |
+| args.metricsAddr | string | `":8080"` | The address the metric endpoint binds to. |
+| args.namespace | string | `"argocd"` | The controller namespace. |
 | config | object | `{"argoCDAuthToken":"example-token","argoCDInsecure":"true","argoCDServerAddr":"argocd-server"}` | Config options |
 | config.argoCDAuthToken | string | `"example-token"` | ArgoCD token |
 | config.argoCDInsecure | string | `"true"` | Allow insecure connection with ArgoCD server |

--- a/charts/applicationset-progressive-sync/templates/deployment.yaml
+++ b/charts/applicationset-progressive-sync/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- if or (gt ( .Values.replicaCount | int64) 1) .Values.args.enableLeaderElection }}
             - --enable-leader-election=true
             {{- end }}
-            - --namespace={{ .Values.args.Namespace }}
+            - --ctrl-namespace={{ .Release.Namespace }}
             - --argo-namespace={{ .Values.args.argoNamespace }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/applicationset-progressive-sync/templates/deployment.yaml
+++ b/charts/applicationset-progressive-sync/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
             {{- if or (gt ( .Values.replicaCount | int64) 1) .Values.args.enableLeaderElection }}
             - --enable-leader-election=true
             {{- end }}
+            - --namespace={{ .Values.args.Namespace }}
+            - --argo-namespace={{ .Values.args.argoNamespace }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/applicationset-progressive-sync/values.yaml
+++ b/charts/applicationset-progressive-sync/values.yaml
@@ -17,8 +17,6 @@ args:
   metricsAddr: :8080
   # -- Enable leader election for controller manager.
   enableLeaderElection: false
-  # -- The controller namespace.
-  namespace: argocd
   # --  The namespace where ArgoCD and the ApplicationSet controller are deployed to.
   argoNamespace: argocd
 

--- a/charts/applicationset-progressive-sync/values.yaml
+++ b/charts/applicationset-progressive-sync/values.yaml
@@ -13,8 +13,14 @@ image:
   tag: ""
 
 args:
+  # -- The address the metric endpoint binds to.
   metricsAddr: :8080
+  # -- Enable leader election for controller manager.
   enableLeaderElection: false
+  # -- The controller namespace.
+  namespace: argocd
+  # --  The namespace where ArgoCD and the ApplicationSet controller are deployed to.
+  argoNamespace: argocd
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/applicationset-progressive-sync/values.yaml
+++ b/charts/applicationset-progressive-sync/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 installCRDs: false
 
 image:
-  repository: maruina/applicationset-progressive-sync
+  repository: ghcr.io/skyscanner/applicationset-progressive-sync
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Update the chart to support the latest command options and `appVersion`.

Blocked by #130 and #132 .