### PR TITLE
Fix the URL for downloading the kubebuilder

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -23,7 +23,7 @@ jobs:
           version=2.3.1
           os=$(go env GOOS)
           arch=$(go env GOARCH)
-          curl -Ls https://go.kubebuilder.io/dl/${version}/${os}/${arch} -o /tmp/kubebuilder_${version}.tar.gz
+          curl -Ls https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_${os}_${arch}.tar.gz -o /tmp/kubebuilder_${version}.tar.gz
           shasum -a 256 -c kubebuilder_sha256.txt
           tar -xzf /tmp/kubebuilder_${version}.tar.gz -C /tmp/
           sudo mv /tmp/kubebuilder_${version}_${os}_${arch} /usr/local/kubebuilder


### PR DESCRIPTION
## Background
Following the discussion [here](https://github.com/Skyscanner/applicationset-progressive-sync/pull/135#discussion_r709213929), we agreed that we should do this as a separate PR. Changed due to kubernetes-sigs/kubebuilder#2311

## Changes
Updates the URL for downloading kubebuilder.