### PR TITLE
allow to configure client plaintext connection

### DIFF
--- a/charts/applicationset-progressive-sync/Chart.yaml
+++ b/charts/applicationset-progressive-sync/Chart.yaml
@@ -16,7 +16,7 @@ version: 0.5.1-prealpha
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.5.1-prealpha"
+appVersion: "v0.5.0-prealpha"
 
 keywords:
   - argoproj

--- a/charts/applicationset-progressive-sync/Chart.yaml
+++ b/charts/applicationset-progressive-sync/Chart.yaml
@@ -10,13 +10,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0-prealpha
+version: 0.5.1-prealpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.0-prealpha"
+appVersion: "v0.5.1-prealpha"
 
 keywords:
   - argoproj

--- a/charts/applicationset-progressive-sync/templates/secret.yaml
+++ b/charts/applicationset-progressive-sync/templates/secret.yaml
@@ -13,4 +13,5 @@ data:
   ARGOCD_AUTH_TOKEN: {{ .Values.config.argoCDAuthToken | b64enc }}
   ARGOCD_SERVER_ADDR: {{ .Values.config.argoCDServerAddr | b64enc }}
   ARGOCD_INSECURE: {{ .Values.config.argoCDInsecure | b64enc }}
+  ARGOCD_PLAINTEXT: {{ .Values.config.argoCDPlaintext | b64enc }}
 {{- end }}

--- a/charts/applicationset-progressive-sync/values.yaml
+++ b/charts/applicationset-progressive-sync/values.yaml
@@ -80,3 +80,5 @@ config:
   argoCDServerAddr: "argocd-server"
   # -- Allow insecure connection with ArgoCD server
   argoCDInsecure: "true"
+  # -- Allow http connection with ArgoCD server
+  argoCDPlaintext: "false"

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -7,6 +7,7 @@ const (
 	AppSetAPIGroup          = "argoproj.io/v1alpha1"
 	ArgoCDAuthTokenKey      = "ARGOCD_AUTH_TOKEN"
 	ArgoCDInsecureKey       = "ARGOCD_INSECURE"
+	ArgoCDPlaintextKey      = "ARGOCD_PLAINTEXT"
 	ArgoCDServerAddrKey     = "ARGOCD_SERVER_ADDR"
 	ConfigDirectory         = "/etc/prcconfig/"
 )

--- a/internal/utils/argocd_client.go
+++ b/internal/utils/argocd_client.go
@@ -18,6 +18,7 @@ func GetArgoCDAppClient(c Configuration) ArgoCDAppClient {
 		ServerAddr: c.ArgoCDServerAddr,
 		Insecure:   c.ArgoCDInsecure,
 		AuthToken:  c.ArgoCDAuthToken,
+		PlainText:  c.ArgoCDPlaintext,
 	}
 
 	acdClient := argocdclient.NewClientOrDie(&acdClientOpts)

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -13,6 +13,7 @@ type Configuration struct {
 	ArgoCDAuthToken  string
 	ArgoCDServerAddr string
 	ArgoCDInsecure   bool
+	ArgoCDPlaintext  bool
 }
 
 // readFromFile returns the content of a file
@@ -67,7 +68,7 @@ func isFlagSet(paramName string) (bool, error) {
 func ReadConfiguration() (Configuration, error) {
 	var err error
 	var acdAuthToken, acdServerAddr string
-	var acdInsecure bool
+	var acdInsecure, acdPlaintext bool
 
 	acdAuthToken, err = readFromEnvOrFile(consts.ArgoCDAuthTokenKey)
 	if err != nil {
@@ -84,10 +85,16 @@ func ReadConfiguration() (Configuration, error) {
 		return Configuration{}, err
 	}
 
+	acdPlaintext, err = isFlagSet(consts.ArgoCDPlaintextKey)
+	if err != nil {
+		return Configuration{}, err
+	}
+
 	c := Configuration{
 		ArgoCDAuthToken:  acdAuthToken,
 		ArgoCDServerAddr: acdServerAddr,
 		ArgoCDInsecure:   acdInsecure,
+		ArgoCDPlaintext:  acdPlaintext,
 	}
 
 	return c, nil


### PR DESCRIPTION
hello! thanks for very useful argo extention!
Please consider following change:
allow to configure client plaintext connection, when applicationset-progressive-sync is running in the same cluster with argocd this will allow to use argocd svc as address `ARGOCD_SERVER_ADDR=argocd-server:80`