### PR TITLE
Don't push on PRs

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -55,3 +55,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+        if: github.event_name != 'pull_request'


### PR DESCRIPTION
Pushing an artifact for every PR breaks external contribution and dependabot, as we can see https://github.com/Skyscanner/applicationset-progressive-sync/runs/4522861353?check_suite_focus=true and https://github.com/Skyscanner/applicationset-progressive-sync/runs/4363099588?check_suite_focus=true