### PR TITLE
Ensure all the Applications have the same revision

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -97,3 +97,17 @@ func Min(x, y int) int {
 	}
 	return y
 }
+
+// HaveSameRevision returns true if the given Applications have the same status.sync.revision
+func HaveSameRevision(apps []argov1alpha1.Application) bool {
+	set := make(map[string]struct{})
+
+	for _, app := range apps {
+		revision := app.Status.Sync.Revision
+		if _, ok := set[revision]; !ok {
+			set[revision] = struct{}{}
+		}
+	}
+
+	return len(set) == 1
+}


### PR DESCRIPTION
Fix an issue reported in https://github.com/Skyscanner/applicationset-progressive-sync/issues/147#issuecomment-1020074054

When the remote repository is updated, ArgoCD starts marking all the Applications pointing to it as `out of sync`.

This PR ensures the controller doesn't start until ArgoCD has updated all the Applications.