### PR TITLE
skip stage if no clusters were targeted

### DIFF
--- a/api/v1alpha1/progressivesync_types.go
+++ b/api/v1alpha1/progressivesync_types.go
@@ -81,6 +81,8 @@ const (
 	StageStatusProgressing StageStatus = "StageProgressing"
 
 	StageStatusFailed StageStatus = "StageFailed"
+
+	StageStatusSkipped StageStatus = "StageSkipped"
 )
 
 // ProgressiveSyncStatus defines the observed state of ProgressiveSync

--- a/api/v1alpha1/progressivesync_types.go
+++ b/api/v1alpha1/progressivesync_types.go
@@ -81,8 +81,6 @@ const (
 	StageStatusProgressing StageStatus = "StageProgressing"
 
 	StageStatusFailed StageStatus = "StageFailed"
-
-	StageStatusSkipped StageStatus = "StageSkipped"
 )
 
 // ProgressiveSyncStatus defines the observed state of ProgressiveSync

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -372,7 +372,6 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 
 	// Skip stage if no clusters targeted
 	if len(selectedClusters.Items) == 0 {
-		log.Info("Skip stage as no clusters targeted", "stage", stage.Name)
 		return syncv1alpha1.StageStatusCompleted, nil
 	}
 

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -369,6 +369,13 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 	if err != nil {
 		return syncv1alpha1.StageStatusFailed, err
 	}
+
+	// Skip stage if no clusters targeted
+	if len(selectedClusters.Items) == 0 {
+		log.Info("Skip stage as no clusters targeted", "stage", stage.Name)
+		return syncv1alpha1.StageStatusSkipped, nil
+	}
+
 	// Get the ArgoCD apps targeting the selected clusters
 	selectedApps, err := r.getOwnedAppsFromClusters(ctx, selectedClusters, ps)
 	if err != nil {

--- a/controllers/progressivesync_controller.go
+++ b/controllers/progressivesync_controller.go
@@ -373,7 +373,7 @@ func (r *ProgressiveSyncReconciler) reconcileStage(ctx context.Context, ps syncv
 	// Skip stage if no clusters targeted
 	if len(selectedClusters.Items) == 0 {
 		log.Info("Skip stage as no clusters targeted", "stage", stage.Name)
-		return syncv1alpha1.StageStatusSkipped, nil
+		return syncv1alpha1.StageStatusCompleted, nil
 	}
 
 	// Get the ArgoCD apps targeting the selected clusters

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -365,7 +365,7 @@ func TestReconcile(t *testing.T) {
 
 		ps := newProgressiveSync("zero-clusters", ns.Name, appSet)
 		ps.Spec.Stages = []syncv1alpha1.Stage{
-			newStage("stage-missing-cluster", 1, 1, metav1.LabelSelector{
+			newStage("stage missing cluster", 1, 1, metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"cluster": "missing-cluster",
 				}}),

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -365,6 +365,10 @@ func TestReconcile(t *testing.T) {
 
 		ps := newProgressiveSync("zero-clusters", ns.Name, appSet)
 		ps.Spec.Stages = []syncv1alpha1.Stage{
+			newStage("stage-missing-cluster", 1, 1, metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"cluster": "missing-cluster",
+				}}),
 			newStage("stage one cluster", 1, 1, metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"cluster": "account6-eu-west-1a-1",

--- a/controllers/progressivesync_controller_test.go
+++ b/controllers/progressivesync_controller_test.go
@@ -365,7 +365,7 @@ func TestReconcile(t *testing.T) {
 
 		ps := newProgressiveSync("zero-clusters", ns.Name, appSet)
 		ps.Spec.Stages = []syncv1alpha1.Stage{
-			newStage("stage missing cluster", 1, 1, metav1.LabelSelector{
+			newStage("stage-missing-cluster", 1, 1, metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"cluster": "missing-cluster",
 				}}),


### PR DESCRIPTION
fix/workaround for https://github.com/Skyscanner/applicationset-progressive-sync/issues/146

basically the idea is to skip stage if targets returned empty list.

This also deserves a test but atm I do not have capacity for this :(