### PR TITLE
Adding a comment on the ArgoCD secret

### DIFF
--- a/hack/dev/secrets.yml
+++ b/hack/dev/secrets.yml
@@ -1,3 +1,5 @@
+# To the security researchers out there: this is a _fake_ secret. it is used to simulate the existence of a secret during CI time
+# we do not use this fake secret anywhere. This is not a password leakage here.
 kind: Secret
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Adding a comment to inform security researches that the ArgoCD secret used for CI
is not a password leakage on our behalf.

This is simply needed to bootstrap ArgoCD in a local environment and test the controller with
the full CRDs + app-progressive-sync.
